### PR TITLE
feat: Rounding up Open Quartz & Prototype; Build code & info

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,12 +1,13 @@
 AudioQuake, Level Description Language and distributed software---Licences
 ==========================================================================
 
-This file aims to clarify the licencing terms that AudioQuake, Level
-Description Language (LDL) and the supporting data and programs
-distributed with them (not all created by us) fall under. It exists to
-make sure that you're completely aware of what you (and we) can and
-can't do with the software. Each section describes a component of the
-AudioQuake and LDL distribution and the licence used for it.
+This file describes the licencing terms for AudioQuake, the Level
+Description Language (LDL) tools and the supporting data and programs
+distributed with them (not all created by us). It exists to make sure
+that you're completely aware of what you (and we) can and can't do with
+the software. After the following summary, each section describes a
+component of the AudioQuake and LDL distribution and the licence used
+for it.
 
 tl;dr:
 ------
@@ -20,7 +21,8 @@ There are three licences in use:
 -   The Prototype textures are copyright 2017-2019 by Aleksander
     "Khreathor" Marhall (<khreathor@khreathor.xyz>;
     <https://twitter.com/khreathor>). They're freely usable in Quake or
-    any game, as long as Aleksander gets a credit---thanks Aleksander!
+    any game, as long as Aleksander gets a credit, which is totally
+    reasonable: thanks Aleksander!
 -   Everything else is distributed under the GNU General Public Licence
     (GPL), version 2 or later.
 
@@ -30,6 +32,32 @@ ZQuake
 This is the QuakeWorld game engine on which AudioQuake is based. It is
 distributed under the GNU General Public Licence (GPL). For more
 information, please read the COPYING file.
+
+Quake map compilation tools
+---------------------------
+
+This repo builds on id's "Quake Tools" code, which is also released
+under the GNU GPL.
+
+That code is linked to this repo via a submodule, and the compiled tools
+are distributed as part of the AudioQuake and LDL bundle. Some patches
+(maintained in this repo) are applied to ensure the software will build,
+and to relax constraints it places on the paths where WAD files are
+located. Those patches, as they're both applicable to GPL'd software,
+and reside in this repo, are too distributed under the GPL.
+
+Open Quartz data pack
+---------------------
+
+The Open Quartz game data, which includes sounds, textures, models,
+maps, gamecode (although the AGRIP gamecode is used instead) and UI
+graphics, is included out-of-the-box. This means you can have fun right
+away, even if you haven't bought Quake. You can make maps and play
+multiplayer games with Open Quartz.
+
+The project is hosted on another service, but development stopped some
+time ago, so the latest data files are included here and, as usual, are
+covered by the GNU GPL.
 
 AudioQuake (gamecode and data)
 ------------------------------
@@ -45,8 +73,8 @@ under the GPL too. Please check out the [AudioQuake
 ACKNOWLEDGEMENTS](audioquake/ACKNOWLEDGEMENTS.md) file for details---and
 many thanks to everyone on whose work we've been able to build!
 
-AudioQuake Launcher
--------------------
+AudioQuake and LDL launcher
+---------------------------
 
 The launcher is a separate program to the game engine and data. It
 provides a UI for running, customising, modding and making maps for the
@@ -54,31 +82,11 @@ game, as well as text-to-speech facilities for when the game is running.
 Again, this is distributed under the GNU GPL. For details on what this
 means, please consult the COPYING file.
 
-Level Description Language
---------------------------
+Level Description Language tools
+--------------------------------
 
-The LDL library and UI (integrated into the AudioQuake launcher) were
-developed as part of AGRIP and are released under the GNU GPL, as above.
-
-Quake map compilation tools
----------------------------
-
-This repo builds on id's "Quake Tools" code, which is also released
-under the GNU GPL.
-
-That code is linked to this repo via a submodule, and the compiled tools
-are distributed as part of the AudioQuake and LDL bundle. Some patches
-(maintained in this repo) are applied to ensure the software will build,
-and to relax constraints it places on the paths where WAD files are
-located. Those patches, as they're both applicable to GPL'd software,
-and reside in this repo, are too distributed under the GPL.
-
-AudioQuake and Level Description Language documentation
--------------------------------------------------------
-
-The manual for AudioQuake and documentation for LDL are distributed
-under the GNU Free Documentation Licence (FDL). A copy of this is
-included in an appendix of the AudioQuake manual.
+The LDL library and UI (integrated into the launcher) were developed as
+part of AGRIP and are released under the GNU GPL, as above.
 
 Prototype textures
 ------------------
@@ -87,3 +95,10 @@ These textures are used in the high-contrast variants of maps. They are
 freely usable in Quake or other games, and are copyright 2017-2019 by
 Aleksander "Khreathor" Marhall (<khreathor@khreathor.xyz>;
 <https://twitter.com/khreathor>). Thank you, Aleksander!
+
+AudioQuake and Level Description Language documentation
+-------------------------------------------------------
+
+The manual for AudioQuake and documentation for LDL are distributed
+under the GNU Free Documentation Licence (FDL). A copy of this is
+included in an appendix of the AudioQuake manual.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 AGRIP AudioQuake and Level Description Language
 ===============================================
 
+***Quake* has a "15" certificate. For obvious reasons, we do not
+recommend nor condone the use of this software by anyone below 15 years
+of age.**
+
 *AudioQuake* and the *Level Description Language* were successful
 experiments started in 2003 to see if it was possible to make a
 mainstream first-person shooter (FPS) accessible to blind and
@@ -58,10 +62,9 @@ most-welcome Star Wars conversions to "excessive overkill"-style
 fragfests. The standard modding tools can be used for this, as they are
 inherently accessible.
 
-You need the official *Quake* data files for the game to work.
-
-*Quake* has a "15" certificate. For obvious reasons, we do not recommend
-nor condone the use of this software by anyone below 15 years of age.
+You can play right away because the Open Quartz community-made data pack
+is included. You can also buy the official *Quake* data files for use
+with the game too (instructions can be found in the user manual).
 
 Level Description Language
 --------------------------

--- a/audioquake/.gitignore
+++ b/audioquake/.gitignore
@@ -1,9 +1,7 @@
-# Manual intermediate files
 manuals-converted/
-# Compiled maps dirs
 maps-freewad/
 maps-quakewad/
 maps-prototypewad/
-# PyInstaller output
 build/
 dist/
+audioquake.ini

--- a/audioquake/AudioQuake.py
+++ b/audioquake/AudioQuake.py
@@ -5,6 +5,7 @@ import traceback
 
 import wx
 
+from launcherlib.config import init as init_config
 from launcherlib.ui.launcher import LauncherWindow
 from launcherlib.ui.helpers import MsgBox
 
@@ -25,5 +26,6 @@ if __name__ == '__main__':
 	app = wx.App()
 	sys.excepthook = error_hook
 	chdir(getattr(sys, '_MEIPASS', path.abspath(path.dirname(__file__))))
+	init_config()
 	LauncherWindow(None, "AudioQuake and LDL Launcher").Show()
 	app.MainLoop()

--- a/audioquake/AudioQuake.spec
+++ b/audioquake/AudioQuake.spec
@@ -1,5 +1,5 @@
 # vim: ft=python
-from buildlib import Config, platform_set, platform_set_only_on
+from buildlib import Config, doset, doset_only
 
 data_files = [
 	('mod-static-files/', 'id1'),
@@ -32,7 +32,7 @@ data_files = [
 if next(Config.dir_maps_quakewad.glob('*.bsp'), None) is not None:
 	data_files.extend([('maps-quakewad/*.bsp', 'id1/maps/')])
 
-binary_files = platform_set(
+binary_files = doset(
 	mac=[
 		('../giants/zq-repo/zquake/release-mac/zqds', '.'),
 		('../giants/zq-repo/zquake/release-mac/zquake-glsdl', '.'),
@@ -64,7 +64,7 @@ a = Analysis(  # noqa 821
 
 pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)  # noqa 821
 
-platform_icon = platform_set(
+platform_icon = doset(
 	mac='app-support-files/aq.icns',
 	windows='app-support-files/aq.ico')
 
@@ -88,7 +88,7 @@ coll = COLLECT(  # noqa 821
 	upx=True,
 	name='AudioQuake')
 
-info_plist = platform_set_only_on(
+info_plist = doset_only(
 	mac={
 		'NSRequiresAquaSystemAppearance': 'No'  # Support dark mode
 	})

--- a/audioquake/BUILD.md
+++ b/audioquake/BUILD.md
@@ -6,14 +6,24 @@ Please ensure you've read and followed the steps in [the main BUILD.md file](../
 If you want to build AudioQuake separately, and have the development environment set up already, it's as simple as running:
 
 * **Mac:** `./build-audioquake.py`
+
 * **Windows:** `python build-audioquake.py`
 
 What does `build-audioquake.py` do?
 -----------------------------------
 
 1. Converts the user manual, sound legend appendix (so it can be referred to separately), development manuals, README and LICENCE files from Markdown to HTML.
-2. Runs [PyInstaller](http://www.pyinstaller.org) to "freeze" the Python code (so that it runs like a normal executable, without requiring Python on the player's computer) and combine it with...
+
+2. Uses the Quake map tools to compile the AGRIP maps (which were originally made with [QuArK](http://quark.sourceforge.net/) for all three different variants of play: Quake, Open Quartz and the "high-contrast" textures from Prototype.wad.
+
+   In Quake, textures are compiled into the ".bsp" files directly from the texture ".wad" files. If this is the first time you're building AudioQuake
+
+3. Runs [PyInstaller](http://www.pyinstaller.org) to "freeze" the Python code (so that it runs like a normal executable, without requiring Python on the player's computer) and combine it with...
+
    + The engine, gamecode and map compilation tools (built using the "build-giants.py" script in the root directory).
+
    + The Level Description Language tools (from the "ldl" subdirectory).
+
    + The AudioQuake game assets (sounds etc.) from this directory.
+
    + The Remote console client written in Python, also from this directory.

--- a/audioquake/CHANGELOG.md
+++ b/audioquake/CHANGELOG.md
@@ -1,25 +1,33 @@
-AudioQuake 2020.0 (??/??/2020)
-==============================
+AudioQuake 2020.0 (Latest beta: ??/??/2020)
+===========================================
 
-This is a re-release in which we've massively revamped the code -- including
-the Level Description Language -- to run on modern platforms, with a new
-GUI-based launcher/level-builder and modern, cross-platform build system. There
-are no functionality changes, but it should be a great deal easier to get, play
-and modify the game now. Whilst no longer relevant in the mainstream sense, we
-wanted to make sure that the game would still run, and that you could more
-easily make levels for it.
+This is a re-release in which we've massively revamped the
+code---including the Level Description Language (LDL)---to run on modern
+platforms, with a new GUI-based launcher and a new cross-platform build
+system. There are some new features, and it should be a great deal
+easier to get, play and modify the game now. Whilst no longer
+mainstream, we wanted to make sure that the game would still run, and
+that you could more easily make levels for it.
 
-**Technical change highlights:**
-
-* Level Description Language tools and tutorials included with the game.
-* Shiny new GUI launcher (based on wxWidgets).
-* Slicker Text-to-Speech performance.
-* The launcher can load in the registered Quake data if you bought the game.
-* ??? You can now also install QMOD files via the GUI.
-* ??? Documentation updates.
-* Much code cleanup behind the scenes.
-  - All of the Python code has been tidied up a lot.
-  - We are now using PyInstaller to bundle the app.
+-   Level Description Language (LDL) tools and tutorials are included
+    with the game.
+-   Shiny new GUI launcher (based on wxWidgets), with all the main
+    features of the previous text-based launcher (including QMOD and
+    registered Quake data installation) and more.
+-   You can play out-of-the-box courtesy of the Open Quartz community
+    data pack.
+-   Levels you make can be played using Quake or Open Quartz textures,
+    or a new set of high-contrast textures.
+-   More flexible styling of LDL maps (supporting the above sets of
+    textures, as well as additional styles you can apply to parts of
+    maps, e.g. to make some areas appear outside).
+-   The launcher can load in the registered Quake data if you bought the
+    game.
+-   Big documentation updates.
+-   Much code clean-up behind the scenes.
+    -   All of the Python code has been tidied up a lot.
+    -   We are now using PyInstaller to bundle the app.
+    -   Slicker text-to-speech performance.
 
 AudioQuake 0.3.0 (02/01/2008)
 =============================
@@ -29,16 +37,16 @@ that aims to take accessibility and community involvement to its logical
 extreme. This release represents a move in game engine and many months
 of hard work. So much has changed that only a summary is given here.
 
--   Move to the ZQuake QuakeWorld engine -- the first Open Source
+-   Move to the ZQuake QuakeWorld engine---the first Open Source
     mainstream accessible game engine (many thanks to Tonik and the
     other developers for allowing our patches in).
 -   Port of the AccessibleQuake game code to ZQuake's QuakeC system
     (which supports multiple online and offline gametypes).
--   Internet Multiplayer support -- Yes; you can play Quake online a
+-   Internet Multiplayer support---Yes; you can play Quake online a
     variety of game modes!
--   Internet Game Server -- Set up your own games with total control
-    over maps and game rules.
--   Online statistics -- track your progress with respect to other
+-   Internet Game Server---Set up your own games with total control over
+    maps and game rules.
+-   Online statistics---track your progress with respect to other
     AudioQuake players.
 -   http://stats.agrip.org.uk/ is a portal for all online features of
     the game.
@@ -49,7 +57,7 @@ of hard work. So much has changed that only a summary is given here.
     Linux, as well as being able to use the data from the downloadable
     version of Quake for Windows.
 -   Many bug fixes and feature enhancements to both the engine and game
-    code in this move -- such as new footstep sounds (from Davy Loots)
+    code in this move---such as new footstep sounds (from Davy Loots)
     and movement speed indication, ESR enhancements and general gameplay
     review.
 
@@ -75,7 +83,7 @@ project we now host ("AudioQuake").
 -   Made ESR level determination Z tolerance configurable (it was a very
     long time ago, as I remember).
 
--   Major line editing improvements -- punctuation characters (such as
+-   Major line editing improvements---punctuation characters (such as
     the bang, tick dot and dash) are now announced properly when typed
     or reviewed.
 
@@ -125,18 +133,18 @@ made because there have been a number of big improvements.
     and Visual Studio Installer 1.1 (used to create ".msi"s out of the
     SAPI 5.1 redist' ".msm"s).
 
--   After too many problems -- the killer being that Windows just
-    doesn't do pipes -- we have fallen back to using Perl for the
-    start-agrip / TTS interface launcher. This does have the advantage
-    that we can do a nice cross-platform front-end.
+-   After too many problems---the killer being that Windows just doesn't
+    do pipes---we have fallen back to using Perl for the start-agrip /
+    TTS interface launcher. This does have the advantage that we can do
+    a nice cross-platform front-end.
 
 -   Altered make-release.sh so that it makes separate "nix" and "win32"
     releases. The win32 releases can then be copied to a suitable
     development box where the Inno Setup script can be compiled to
     create executable setup packages.
 
--   Improved my QF patch code to go through Con\_Printf (so that
-    fflush() is done implicitly).
+-   Improved my QF patch code to go through Con_Printf (so that fflush()
+    is done implicitly).
 
 -   Removed a load of sounds from the QuakeC side so as to make way for
     SAPI.
@@ -184,7 +192,7 @@ Whilst in development, this was 0.0.5, but was re-released as 0.1.0
     accessible set-up had been reverted to one that could confuse some
     AGRIP objects.
 
--   Fixed a bug where the bots would render you SOLID\_NOT on coming to
+-   Fixed a bug where the bots would render you SOLID_NOT on coming to
     your aid (caused by me not escaping from the goal item grabbing
     routine if the goal item is a player).
 
@@ -200,7 +208,7 @@ Whilst in development, this was 0.0.5, but was re-released as 0.1.0
 AGRIP 0.0.4 (22/05/2004)
 ========================
 
--   Added jump detection -- you can press J for a description of ho you
+-   Added jump detection---you can press J for a description of ho you
     will be able to make a jump. If the hazard doesn't represent a jump,
     or you can't make it, you'll hear the "access denied" sound. If you
     can make it with a running jump, you'll hear a shotgun-like sound.
@@ -272,9 +280,9 @@ AGRIP 0.0.3 (13/05/2004)
 
 First release after 0.0.x has been extended.
 
--   The "wall\_hit\_warnings" are now "wall\_touch\_warnings". By
-    default they're off but if on, they keep the walls making sound if
-    you're still near them.
+-   The "wall_hit_warnings" are now "wall_touch_warnings". By default
+    they're off but if on, they keep the walls making sound if you're
+    still near them.
 
 -   Added a number of extra configuration options to help make the nav
     system quieter and more customisable (toggles for all

--- a/audioquake/build-audioquake.py
+++ b/audioquake/build-audioquake.py
@@ -11,7 +11,7 @@ import mistune
 import mistune_contrib.toc
 
 from buildlib import Config, \
-	try_to_run, platform_set, check_platform, die, comeback, prep_dir
+	try_to_run, doset, check_platform, die, comeback, prep_dir
 from ldllib.build import build, have_needed_progs, use_repo_bins, \
 	swap_wad, basename_maybe_hc
 from ldllib.convert import use_repo_wads, have_wad, WADs
@@ -203,7 +203,7 @@ def run_pyinstaller():
 
 
 def copy_in_rcon():
-	rcon_bin = platform_set(
+	rcon_bin = doset(
 		mac='rcon',
 		windows='rcon.exe')
 

--- a/audioquake/launcherlib/config.py
+++ b/audioquake/launcherlib/config.py
@@ -1,0 +1,55 @@
+"""AudioQuake Game Launcher - Configuration service"""
+from configparser import ConfigParser
+
+CONFIG_FILENAME = 'audioquake.ini'
+
+INITIAL_CONFIG = {
+	'first_game_run': 'yes'
+}
+
+_config = None
+
+
+def save():
+	with open(CONFIG_FILENAME, 'w') as configfile:
+		_config.write(configfile)
+
+
+def convert_to_string(value):
+	if value is True:
+		return 'yes'
+	elif value is False:
+		return 'no'
+	else:
+		return str(value)
+
+
+def convert_to_type(string):
+	if string == 'yes' or string == 'true':
+		return True
+	elif string == 'no' or string == 'false':
+		return False
+	else:
+		return string
+
+
+def get_or_set_core(name, value=None):
+	if value is None:
+		return convert_to_type(_config['launcher'][name])
+	else:
+		_config['launcher'][name] = convert_to_string(value)
+		save()
+
+
+def __getattr__(name):
+	if name in _config['launcher']:
+		return lambda value=None: get_or_set_core(name, value)
+	else:
+		raise AttributeError(name)
+
+
+_config = ConfigParser()
+_config.read(CONFIG_FILENAME)
+if len(_config) == 1:  # always has a default section
+	_config['launcher'] = INITIAL_CONFIG
+	save()

--- a/audioquake/launcherlib/config.py
+++ b/audioquake/launcherlib/config.py
@@ -1,7 +1,7 @@
 """AudioQuake Game Launcher - Configuration service"""
 from configparser import ConfigParser
 
-CONFIG_FILENAME = 'audioquake.ini'
+CONFIG_FILENAME = 'audioquake.ini'  # i.e. in the current directory
 
 INITIAL_CONFIG = {
 	'first_game_run': 'yes'
@@ -9,13 +9,29 @@ INITIAL_CONFIG = {
 
 _config = None
 
+# This isn't a package, but __path__ has to be set or __getattr__ gets called
+__path__ = None
+
+
+def init():
+	"""Read the existing config file, or create a default one
+
+	Due to the default path (above) this will create the file in the current
+	directory, so needs to be called in the right place."""
+	global _config
+	_config = ConfigParser()
+	_config.read(CONFIG_FILENAME)
+	if len(_config) == 1:  # always has a default section
+		_config['launcher'] = INITIAL_CONFIG
+		save()
+
 
 def save():
 	with open(CONFIG_FILENAME, 'w') as configfile:
 		_config.write(configfile)
 
 
-def convert_to_string(value):
+def _convert_to_string(value):
 	if value is True:
 		return 'yes'
 	elif value is False:
@@ -24,7 +40,7 @@ def convert_to_string(value):
 		return str(value)
 
 
-def convert_to_type(string):
+def _convert_to_type(string):
 	if string == 'yes' or string == 'true':
 		return True
 	elif string == 'no' or string == 'false':
@@ -33,23 +49,16 @@ def convert_to_type(string):
 		return string
 
 
-def get_or_set_core(name, value=None):
+def _get_or_set_core(name, value=None):
 	if value is None:
-		return convert_to_type(_config['launcher'][name])
+		return _convert_to_type(_config['launcher'][name])
 	else:
-		_config['launcher'][name] = convert_to_string(value)
+		_config['launcher'][name] = _convert_to_string(value)
 		save()
 
 
 def __getattr__(name):
 	if name in _config['launcher']:
-		return lambda value=None: get_or_set_core(name, value)
+		return lambda value=None: _get_or_set_core(name, value)
 	else:
 		raise AttributeError(name)
-
-
-_config = ConfigParser()
-_config.read(CONFIG_FILENAME)
-if len(_config) == 1:  # always has a default section
-	_config['launcher'] = INITIAL_CONFIG
-	save()

--- a/audioquake/launcherlib/game_controller/__init__.py
+++ b/audioquake/launcherlib/game_controller/__init__.py
@@ -19,7 +19,7 @@ class RootGame(enum.Enum):
 
 
 class GameController():
-	opts_default = ("-window", "+set sensitivity 0")
+	opts_default = ("-window", "+noskins 1", "+set sensitivity 0")
 	opts_open_quartz = ("-rootgame", "oq")
 	opts_custom_map_base = ("+coop 0", "+deathmatch 0")
 	opts_tutorial = opts_custom_map_base + ("+map agtut01",)

--- a/audioquake/launcherlib/game_controller/__init__.py
+++ b/audioquake/launcherlib/game_controller/__init__.py
@@ -56,7 +56,6 @@ class GameController():
 		else:
 			raise TypeError(f"Invalid game name '{game}'")
 
-		print('_launch_core():', game, parameters)
 		self._engine_wrapper = EngineWrapper(parameters, self._on_error)
 
 		if not self._engine_wrapper.engine_found():

--- a/audioquake/launcherlib/game_controller/engine_wrapper.py
+++ b/audioquake/launcherlib/game_controller/engine_wrapper.py
@@ -4,14 +4,14 @@ import threading
 import subprocess
 import sys
 
-from buildlib import platform_set, only_on
+from buildlib import doset, doset_only
 from launcherlib.game_controller.speech_synth import SpeechSynth
 
 
 class EngineWrapper(threading.Thread):
 	def __init__(self, args, on_error):
 		threading.Thread.__init__(self)
-		self._engine = platform_set(
+		self._engine = doset(
 			mac='./zquake-glsdl',
 			windows='zquake-gl.exe')
 		self._command_line = (self._engine,) + args
@@ -25,10 +25,9 @@ class EngineWrapper(threading.Thread):
 			speaker = SpeechSynth()
 
 			# The docs imply this shouldn't be necessary but it is...
-			# FIXME need only_reassign_on
 			def reassign_commandline():
 				self._command_line = ' '.join(self._command_line)
-			only_on(windows=reassign_commandline)
+			doset_only(windows=reassign_commandline)
 
 			# Buffering may be necessary for Windows; seems not to affect Mac
 			proc = subprocess.Popen(

--- a/audioquake/launcherlib/game_controller/speech_synth.py
+++ b/audioquake/launcherlib/game_controller/speech_synth.py
@@ -1,6 +1,6 @@
 """AudioQuake Game Launcher - Game controller - Speech synth"""
 from platform import system
-from buildlib import do_something
+from buildlib import doset
 
 if system() == 'Darwin':
 	from AppKit import NSSpeechSynthesizer
@@ -13,7 +13,7 @@ else:
 
 class SpeechSynth():
 	def __init__(self):
-		do_something(
+		doset(
 			mac=self._init_mac,
 			windows=self._init_windows)
 

--- a/audioquake/launcherlib/ui/helpers.py
+++ b/audioquake/launcherlib/ui/helpers.py
@@ -5,7 +5,7 @@ import sys
 
 import wx
 
-from buildlib import only_on
+from buildlib import doset_only
 from launcherlib.game_controller import LaunchState
 from launcherlib.utils import opener
 
@@ -48,9 +48,9 @@ def add_launch_button(parent, sizer, title, action):
 	button = wx.Button(parent, -1, title)
 
 	def make_launch_function(game_start_method):
-		def launch(event):
+		def launch_handler(event):
 			launch_core(parent, game_start_method)
-		return launch
+		return launch_handler
 
 	# FIXME server and rcon don't return LaunchStatusy thingies
 
@@ -67,9 +67,9 @@ def add_opener_button(parent, sizer, title, thing_to_open):
 	button = wx.Button(parent, -1, title)
 
 	def make_open_function(openee):
-		def open_thing(event):
+		def open_thing_handler(event):
 			opener(openee)
-		return open_thing
+		return open_thing_handler
 
 	button.Bind(wx.EVT_BUTTON, make_open_function(thing_to_open))
 	add_widget(sizer, button)
@@ -132,7 +132,7 @@ def stamp_file_check(parent, name):
 
 
 def first_time_check(parent, name):
-	only_on(
+	doset_only(
 		windows=lambda: stamp_file_check(parent, name))
 
 

--- a/audioquake/launcherlib/ui/launcher.py
+++ b/audioquake/launcherlib/ui/launcher.py
@@ -1,7 +1,7 @@
 """AudioQuake Game Launcher - Main launcher window"""
 import wx
 
-from buildlib import do_something, only_on
+from buildlib import doset, doset_only
 
 from launcherlib.game_controller import GameController
 from launcherlib.ui.helpers import Warn
@@ -20,7 +20,7 @@ class LauncherWindow(wx.Frame):
 
 		sizer = wx.BoxSizer(wx.VERTICAL)
 
-		notebook = do_something(
+		notebook = doset(
 			mac=lambda: wx.Notebook(self),
 			windows=lambda: wx.Listbook(self))
 
@@ -44,7 +44,7 @@ class LauncherWindow(wx.Frame):
 			menubar = wx.MenuBar()
 			wx.MenuBar.MacSetCommonMenuBar(menubar)
 
-		only_on(mac=set_up_menu_bar)
+		doset_only(mac=set_up_menu_bar)
 
 		# TODO: If Quit on the Menu Bar is used and the engine is running, the
 		# app gets the beachball until the engine is quat and then it quits.

--- a/audioquake/launcherlib/ui/launcher.py
+++ b/audioquake/launcherlib/ui/launcher.py
@@ -21,10 +21,6 @@ class LauncherWindow(wx.Frame):
 		sizer = wx.BoxSizer(wx.VERTICAL)
 
 		notebook = do_something(
-			mac=lambda: print('Mac'),
-			windows=lambda: print('Windows'))
-
-		notebook = do_something(
 			mac=lambda: wx.Notebook(self),
 			windows=lambda: wx.Listbook(self))
 

--- a/audioquake/launcherlib/ui/tabs/customise.py
+++ b/audioquake/launcherlib/ui/tabs/customise.py
@@ -18,14 +18,16 @@ class CustomiseTab(wx.Panel):
 		# Settings
 
 		add_opener_buttons(self, sizer, {
-			'Edit autoexec.cfg': path.join('id1', 'autoexec.cfg'),
-			'Edit config.cfg': path.join('id1', 'config.cfg'),
+			'Edit autoexec.cfg (with default editor)':
+				path.join('id1', 'autoexec.cfg'),
+			'Edit config.cfg (with default editor)':
+				path.join('id1', 'config.cfg'),
 		})
 
 		# Install registered data
 
 		reg_data_button = wx.Button(self, -1, 'Install registered Quake data')
-		reg_data_button.Bind(wx.EVT_BUTTON, self.install_registered_data)
+		reg_data_button.Bind(wx.EVT_BUTTON, self.install_data_handler)
 		add_widget(sizer, reg_data_button)
 
 		# Wiring
@@ -33,7 +35,7 @@ class CustomiseTab(wx.Panel):
 		sizer.SetSizeHints(self)
 		self.SetSizer(sizer)
 
-	def install_registered_data(self, event):
+	def install_data_handler(self, event):
 		if have_registered_data():  # TODO what if something else is missing?
 			Info(self, 'The registered data files are already installed.')
 		else:

--- a/audioquake/launcherlib/ui/tabs/map.py
+++ b/audioquake/launcherlib/ui/tabs/map.py
@@ -89,7 +89,7 @@ class MapTab(wx.Panel):
 
 		texture_set_hbox = wx.BoxSizer(wx.HORIZONTAL)
 
-		label = wx.StaticText(self, label='Texture set:')
+		label = wx.StaticText(self, label='Play map with texture set:')
 		pick = wx.Choice(self, -1, choices=list(game_names.keys()))
 		pick.SetSelection(0)  # Needed on Windows
 
@@ -174,7 +174,9 @@ class MapTab(wx.Panel):
 			launch_core(self, lambda: self.game_controller.launch_map(
 				map_basename, game=play_as_game))
 		else:
-			Info(self, xmlfile.stem + ' built and installed')
+			Info(
+				self, xmlfile.stem
+				+ ' built (for all texture sets) and installed.')
 
 	@staticmethod
 	def build_and_copy(xmlfile, wad, dest_dirs):

--- a/audioquake/launcherlib/ui/tabs/map.py
+++ b/audioquake/launcherlib/ui/tabs/map.py
@@ -124,7 +124,13 @@ class MapTab(wx.Panel):
 			else:
 				play_wad = None
 
-			self.build_and_play(path, play_wad)
+			if path.name == 'tut07.xml' \
+				and not have_wad(WADs.QUAKE, quiet=True):
+				Warn(self, (
+					'Sorry, ' + path.name + ' requires the Quake data '
+					'in order to run. This is a known issue.'))
+			else:
+				self.build_and_play(path, play_wad)
 
 		btn_build.Bind(wx.EVT_BUTTON, build_and_play_handler)
 		add_widget(sizer, btn_build)

--- a/audioquake/launcherlib/ui/tabs/map.py
+++ b/audioquake/launcherlib/ui/tabs/map.py
@@ -89,7 +89,7 @@ class MapTab(wx.Panel):
 
 		texture_set_hbox = wx.BoxSizer(wx.HORIZONTAL)
 
-		label = wx.StaticText(self, label='Play map with texture set:')
+		label = wx.StaticText(self, label='Play map with texture set: ')
 		pick = wx.Choice(self, -1, choices=list(game_names.keys()))
 		pick.SetSelection(0)  # Needed on Windows
 

--- a/audioquake/launcherlib/ui/tabs/mod.py
+++ b/audioquake/launcherlib/ui/tabs/mod.py
@@ -19,11 +19,11 @@ class ModTab(wx.Panel):
 		sizer = wx.BoxSizer(wx.VERTICAL)
 
 		select_qmod_button = wx.Button(self, -1, 'Play a mod')
-		select_qmod_button.Bind(wx.EVT_BUTTON, self.play_mod)
+		select_qmod_button.Bind(wx.EVT_BUTTON, self.play_mod_handler)
 		add_widget(sizer, select_qmod_button)
 
 		install_qmod_button = wx.Button(self, -1, 'Install a mod')
-		install_qmod_button.Bind(wx.EVT_BUTTON, self.install_qmod)
+		install_qmod_button.Bind(wx.EVT_BUTTON, self.install_qmod_handler)
 		add_widget(sizer, install_qmod_button)
 
 		add_opener_buttons(self, sizer, {
@@ -35,7 +35,7 @@ class ModTab(wx.Panel):
 		sizer.SetSizeHints(self)
 		self.SetSizer(sizer)
 
-	def install_qmod(self, event):
+	def install_qmod_handler(self, event):
 		incoming = pick_file(
 			self, "Select a QMOD file", "QMOD files (*.qmod)|*.qmod")
 		if incoming:
@@ -59,7 +59,7 @@ class ModTab(wx.Panel):
 			except:  # noqa E722
 				ErrorException(self)
 
-	def play_mod(self, event):
+	def play_mod_handler(self, event):
 		mod_dirs = list(map(lambda ini: path.dirname(ini), glob('**/qmod.ini')))
 		if len(mod_dirs) > 0:
 			chooser = wx.SingleChoiceDialog(

--- a/audioquake/launcherlib/ui/tabs/play.py
+++ b/audioquake/launcherlib/ui/tabs/play.py
@@ -1,7 +1,7 @@
 """AudioQuake Game Launcher - Play tab"""
 import wx
 
-from buildlib import platform_set
+from buildlib import doset
 from launcherlib.ui.helpers import add_launch_button, add_opener_buttons
 
 
@@ -22,11 +22,11 @@ class PlayTab(wx.Panel):
 		for title, action in game_modes.items():
 			add_launch_button(self, sizer, title, action)
 
-		server = platform_set(
+		server = doset(
 			mac='./start-server.command',
 			windows='zqds.exe')
 
-		rcon = platform_set(
+		rcon = doset(
 			mac='./start-rcon.command',
 			windows='rcon.exe')
 

--- a/audioquake/launcherlib/utils.py
+++ b/audioquake/launcherlib/utils.py
@@ -2,13 +2,13 @@
 import os
 from subprocess import check_call
 
-from buildlib import do_something
+from buildlib import doset
 
 
 def opener(openee):
-	do_something(
-		mac=check_call(['open', openee]),
-		windows=os.startfile(openee))
+	doset(
+		mac=lambda: check_call(['open', openee]),
+		windows=lambda: os.startfile(openee))
 
 
 def have_registered_data():

--- a/audioquake/launcherlib/utils.py
+++ b/audioquake/launcherlib/utils.py
@@ -1,6 +1,10 @@
 """AudioQuake Game Launcher - Utilities"""
-import os
+from pathlib import Path
 from subprocess import check_call
+
+from platform import system
+if system() == 'Windows':
+	from os import startfile
 
 from buildlib import doset
 
@@ -8,10 +12,10 @@ from buildlib import doset
 def opener(openee):
 	doset(
 		mac=lambda: check_call(['open', openee]),
-		windows=lambda: os.startfile(openee))
+		windows=lambda: startfile(openee))
 
 
 def have_registered_data():
-	pak0path = os.path.join('id1', 'pak0.pak')
-	pak1path = os.path.join('id1', 'pak1.pak')
-	return os.path.exists(pak0path) and os.path.exists(pak1path)
+	pak0path = Path('id1') / 'pak0.pak'
+	pak1path = Path('id1') / 'pak1.pak'
+	return pak0path.is_file() and pak1path.is_file()

--- a/audioquake/manuals/development-manual-part01.md
+++ b/audioquake/manuals/development-manual-part01.md
@@ -1,3 +1,9 @@
+Copyright (c)  2005-2020  Matthew Tylee Atkinson
+
+Copyright (c)  2007  Sabahattin Gucukoglu
+
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the section entitled "GNU Free Documentation License".
+
 # Getting Started
 
 ## Digital archaeology note from 2020

--- a/audioquake/manuals/development-manual-part09.md
+++ b/audioquake/manuals/development-manual-part09.md
@@ -9,12 +9,12 @@ This section contains details that the installer and launcher will both use. It 
 
 | Key             | Notes                                                                                                                                                                  | Example(s)                                    |
 | :-------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------- |
-| name            | Name that users are presented with (in the installer and mod list)                                                                                                     | JediQuake                                     |
-| shortdesc       | Short(\!\!) description used by installer and mod list in the launcher                                                                                                 | *AudioQuake* with a Star Wars flair\!           |
-| version         | The (user-facing) version number of your mod                                                                                                                           | 3.7                                           |
-| gamedir         | Which directory your mod must run from                                                                                                                                 | jediquake37                                   |
-| watch\_config   | Should your mod be updated with the user's latest `config.cfg` file when it changes? Note that this does not change your mod's `mod.cfg` file, which has precedence.   | yes (or anything else if you don't want this) |
-| watch\_autoexec | Should your mod be updated with the user's latest `autoexec.cfg` file when it changes? Note that this does not change your mod's `mod.cfg` file, which has precedence. | yes (or anything else if you don't want this) |
+| name            | Name that users are presented with (in the installer and mod list)                                                                                                     | `JediQuake`                                     |
+| shortdesc       | Short(\!\!) description used by installer and mod list in the launcher                                                                                                 | `AudioQuake with a Star Wars flair!`           |
+| version         | The (user-facing) version number of your mod                                                                                                                           | `3.7`                                           |
+| gamedir         | Which directory your mod must run from                                                                                                                                 | `jediquake37`                                   |
+| watch\_config   | Should your mod be updated with the user's latest `config.cfg` file when it changes? Note that this does not change your mod's `mod.cfg` file, which has precedence.   | Either `yes`/`true`/`on`/`1`, or `no`/`false`/`off`/`0`. |
+| watch\_autoexec | Should your mod be updated with the user's latest `autoexec.cfg` file when it changes? Note that this does not change your mod's `mod.cfg` file, which has precedence. | Either `yes`/`true`/`on`/`1`, or `no`/`false`/`off`/`0`. |
 
 #### Example
 

--- a/audioquake/manuals/development-manual-part09.md
+++ b/audioquake/manuals/development-manual-part09.md
@@ -1,5 +1,5 @@
 <a name="qmod-ini"></a>
-# `qmod.ini` file settings
+## `qmod.ini` file settings
 
 The following sections detail the various options available to mod authors in `qmod.ini` files. The are split into the two (current) sections of the INI file—"general" and "longdesc".
 

--- a/audioquake/manuals/development-manual-part10-gfdl-1.2.md
+++ b/audioquake/manuals/development-manual-part10-gfdl-1.2.md
@@ -1,4 +1,4 @@
-### GNU Free Documentation License
+## GNU Free Documentation License
 
 Version 1.2, November 2002
 

--- a/audioquake/manuals/development-manual-part10-gfdl-1.2.md
+++ b/audioquake/manuals/development-manual-part10-gfdl-1.2.md
@@ -1,0 +1,394 @@
+### GNU Free Documentation License
+
+Version 1.2, November 2002
+
+      Copyright (C) 2000,2001,2002  Free Software Foundation, Inc.
+      51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+      
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+
+**0. PREAMBLE**
+
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document "free" in the sense of freedom: to
+assure everyone the effective freedom to copy and redistribute it,
+with or without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible
+for modifications made by others.
+
+This License is a kind of "copyleft", which means that derivative
+works of the document must themselves be free in the same sense. It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does. But this License is not limited to software manuals; it
+can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book. We recommend this License
+principally for works whose purpose is instruction or reference.
+
+**1. APPLICABILITY AND DEFINITIONS**
+
+This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License. Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein. The "Document", below, refers
+to any such manual or work. Any member of the public is a licensee,
+and is addressed as "you". You accept the license if you copy, modify
+or distribute the work in a way requiring permission under copyright
+law.
+
+A "Modified Version" of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A "Secondary Section" is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall
+subject (or to related matters) and contains nothing that could fall
+directly within that overall subject. (Thus, if the Document is in
+part a textbook of mathematics, a Secondary Section may not explain
+any mathematics.) The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The "Invariant Sections" are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License. If a
+section does not fit the above definition of Secondary then it is not
+allowed to be designated as Invariant. The Document may contain zero
+Invariant Sections. If the Document does not identify any Invariant
+Sections then there are none.
+
+The "Cover Texts" are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License. A Front-Cover Text may be
+at most 5 words, and a Back-Cover Text may be at most 25 words.
+
+A "Transparent" copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, that is suitable for revising the document
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters. A copy made in an otherwise Transparent file
+format whose markup, or absence of markup, has been arranged to thwart
+or discourage subsequent modification by readers is not Transparent.
+An image format is not Transparent if used for any substantial amount
+of text. A copy that is not "Transparent" is called "Opaque".
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML
+or XML using a publicly available DTD, and standard-conforming simple
+HTML, PostScript or PDF designed for human modification. Examples of
+transparent image formats include PNG, XCF and JPG. Opaque formats
+include proprietary formats that can be read and edited only by
+proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the
+machine-generated HTML, PostScript or PDF produced by some word
+processors for output purposes only.
+
+The "Title Page" means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page. For works in
+formats which do not have any title page as such, "Title Page" means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+A section "Entitled XYZ" means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language. (Here XYZ stands for a
+specific section name mentioned below, such as "Acknowledgements",
+"Dedications", "Endorsements", or "History".) To "Preserve the Title"
+of such a section when you modify the Document means that it remains a
+section "Entitled XYZ" according to this definition.
+
+The Document may include Warranty Disclaimers next to the notice which
+states that this License applies to the Document. These Warranty
+Disclaimers are considered to be included by reference in this
+License, but only as regards disclaiming warranties: any other
+implication that these Warranty Disclaimers may have is void and has
+no effect on the meaning of this License.
+
+**2. VERBATIM COPYING**
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no
+other conditions whatsoever to those of this License. You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute. However, you may accept
+compensation in exchange for copies. If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+**3. COPYING IN QUANTITY**
+
+If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document's license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover. Both covers must also clearly and legibly identify you
+as the publisher of these copies. The front cover must present the
+full title with all words of the title equally prominent and visible.
+You may add other material on the covers in addition. Copying with
+changes limited to the covers, as long as they preserve the title of
+the Document and satisfy these conditions, can be treated as verbatim
+copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a computer-network location from which the general network-using
+public has access to download using public-standard network protocols
+a complete Transparent copy of the Document, free of added material.
+If you use the latter option, you must take reasonably prudent steps,
+when you begin distribution of Opaque copies in quantity, to ensure
+that this Transparent copy will remain thus accessible at the stated
+location until at least one year after the last time you distribute an
+Opaque copy (directly or through your agents or retailers) of that
+edition to the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to
+give them a chance to provide you with an updated version of the
+Document.
+
+**4. MODIFICATIONS**
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it. In addition, you must do these things in the Modified Version:
+
+-   **A.** Use in the Title Page (and on the covers, if any) a title
+    distinct from that of the Document, and from those of previous
+    versions (which should, if there were any, be listed in the
+    History section of the Document). You may use the same title as a
+    previous version if the original publisher of that version
+    gives permission.
+-   **B.** List on the Title Page, as authors, one or more persons or
+    entities responsible for authorship of the modifications in the
+    Modified Version, together with at least five of the principal
+    authors of the Document (all of its principal authors, if it has
+    fewer than five), unless they release you from this requirement.
+-   **C.** State on the Title page the name of the publisher of the
+    Modified Version, as the publisher.
+-   **D.** Preserve all the copyright notices of the Document.
+-   **E.** Add an appropriate copyright notice for your modifications
+    adjacent to the other copyright notices.
+-   **F.** Include, immediately after the copyright notices, a license
+    notice giving the public permission to use the Modified Version
+    under the terms of this License, in the form shown in the
+    Addendum below.
+-   **G.** Preserve in that license notice the full lists of Invariant
+    Sections and required Cover Texts given in the Document's
+    license notice.
+-   **H.** Include an unaltered copy of this License.
+-   **I.** Preserve the section Entitled "History", Preserve its
+    Title, and add to it an item stating at least the title, year, new
+    authors, and publisher of the Modified Version as given on the
+    Title Page. If there is no section Entitled "History" in the
+    Document, create one stating the title, year, authors, and
+    publisher of the Document as given on its Title Page, then add an
+    item describing the Modified Version as stated in the
+    previous sentence.
+-   **J.** Preserve the network location, if any, given in the
+    Document for public access to a Transparent copy of the Document,
+    and likewise the network locations given in the Document for
+    previous versions it was based on. These may be placed in the
+    "History" section. You may omit a network location for a work that
+    was published at least four years before the Document itself, or
+    if the original publisher of the version it refers to
+    gives permission.
+-   **K.** For any section Entitled "Acknowledgements" or
+    "Dedications", Preserve the Title of the section, and preserve in
+    the section all the substance and tone of each of the contributor
+    acknowledgements and/or dedications given therein.
+-   **L.** Preserve all the Invariant Sections of the Document,
+    unaltered in their text and in their titles. Section numbers or
+    the equivalent are not considered part of the section titles.
+-   **M.** Delete any section Entitled "Endorsements". Such a section
+    may not be included in the Modified Version.
+-   **N.** Do not retitle any existing section to be Entitled
+    "Endorsements" or to conflict in title with any Invariant Section.
+-   **O.** Preserve any Warranty Disclaimers.
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant. To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section Entitled "Endorsements", provided it contains
+nothing but endorsements of your Modified Version by various
+parties--for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version. Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity. If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+**5. COMBINING DOCUMENTS**
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice, and that you preserve all their Warranty Disclaimers.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy. If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections Entitled "History"
+in the various original documents, forming one section Entitled
+"History"; likewise combine any sections Entitled "Acknowledgements",
+and any sections Entitled "Dedications". You must delete all sections
+Entitled "Endorsements."
+
+**6. COLLECTIONS OF DOCUMENTS**
+
+You may make a collection consisting of the Document and other
+documents released under this License, and replace the individual
+copies of this License in the various documents with a single copy
+that is included in the collection, provided that you follow the rules
+of this License for verbatim copying of each of the documents in all
+other respects.
+
+You may extract a single document from such a collection, and
+distribute it individually under this License, provided you insert a
+copy of this License into the extracted document, and follow this
+License in all other respects regarding verbatim copying of that
+document.
+
+**7. AGGREGATION WITH INDEPENDENT WORKS**
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an "aggregate" if the copyright
+resulting from the compilation is not used to limit the legal rights
+of the compilation's users beyond what the individual works permit.
+When the Document is included in an aggregate, this License does not
+apply to the other works in the aggregate which are not themselves
+derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document's Cover Texts may be placed on
+covers that bracket the Document within the aggregate, or the
+electronic equivalent of covers if the Document is in electronic form.
+Otherwise they must appear on printed covers that bracket the whole
+aggregate.
+
+**8. TRANSLATION**
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections. You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers. In case of a disagreement between
+the translation and the original version of this License or a notice
+or disclaimer, the original version will prevail.
+
+If a section in the Document is Entitled "Acknowledgements",
+"Dedications", or "History", the requirement (section 4) to Preserve
+its Title (section 1) will typically require changing the actual
+title.
+
+**9. TERMINATION**
+
+You may not copy, modify, sublicense, or distribute the Document
+except as expressly provided for under this License. Any other attempt
+to copy, modify, sublicense or distribute the Document is void, and
+will automatically terminate your rights under this License. However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+**10. FUTURE REVISIONS OF THIS LICENSE**
+
+The Free Software Foundation may publish new, revised versions of the
+GNU Free Documentation License from time to time. Such new versions
+will be similar in spirit to the present version, but may differ in
+detail to address new problems or concerns. See
+https://www.gnu.org/licenses/.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation. If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.
+
+### [How to use this License for your documents]()
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+      Copyright (c)  YEAR  YOUR NAME.
+      Permission is granted to copy, distribute and/or modify this document
+      under the terms of the GNU Free Documentation License, Version 1.2
+      or any later version published by the Free Software Foundation;
+      with no Invariant Sections, no Front-Cover Texts, and no Back-Cover
+      Texts.  A copy of the license is included in the section entitled "GNU
+      Free Documentation License".
+
+If you have Invariant Sections, Front-Cover Texts and Back-Cover
+Texts, replace the "with...Texts." line with this:
+
+      with the Invariant Sections being LIST THEIR TITLES, with the
+      Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+
+If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.
+
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License, to
+permit their use in free software.

--- a/audioquake/manuals/user-manual-part01.md
+++ b/audioquake/manuals/user-manual-part01.md
@@ -1,3 +1,7 @@
+Copyright (c)  2004-2020  Matthew Tylee Atkinson
+
+Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the section entitled "GNU Free Documentation License".
+
 # Introduction
 
 This part of the manual aims to introduce *AudioQuake* and gives you details on how to get it set up on your computer.

--- a/audioquake/manuals/user-manual-part01.md
+++ b/audioquake/manuals/user-manual-part01.md
@@ -80,9 +80,21 @@ We would love to see a community spring up around *AudioQuake* and make other ga
 
 Installing both *AudioQuake* and the *Level Description Language (LDL)* is just a case of extracting the ZIP file you downloaded and running either "AudioQuake.app" on the Mac, or "AudioQuake.exe" on Windows. However, there are a couple of other things you need to know.
 
+### Playing *Open Quartz* out-of-the-box
+
+You need some game data files to actually play the game. *AudioQuake* comes with the Open Source and Free Software *Open Quartz* data pack. It's similar in spirit to *Quake* in that it's a first-person shooter and aims to be a drop-in replacement for *Quake*, but it sounds (and looks) quite different and is a game in its own right (though much smaller in size and scope, and not single-player focused).
+
+You can start playing *Open Quartz* with all the accessibility features that *AudioQuake* provides out-of-the box. You can also make your own maps with *Level Description Language (LDL)* using the *Open Quartz* textures and even some high-contrast textures, courtesy of *Prototype.wad* too.
+
+Whilst using *Open Quartz* supports custom mapping and even some mods originally made for *AudioQuake*, there are some limitations at the moment: *Open Quartz* doesn't have replacements for some of *Quake*'s data, so you will find that some maps and mods won't work.
+
+<!-- FIXME -->
+
+Currently at least one of the *Level Description Language (LDL)* maps requires some of this data and won't run under *Open Quartz*.
+
 ### Buying *Quake*
 
-As explained above, *AudioQuake* is a series of modifications to the game *Quake*. For *AudioQuake* to function correctly, you must have *Quake*. Whilst there is a Shareware episode, it doesn't permit using custom maps, which *AudioQuake* uses a lot of, and the *Level Description Language (LDL)* allows you to write.
+We recommend that you buy *Quake* so you can use its data with *AudioQuake* (not all the levels are accessible, but a number are—having the full *Quake* data also means you can experience its ambience and use it in your own maps). Whilst there is a Shareware episode of *Quake*, it doesn't permit using custom maps, which *AudioQuake* provides, and the *Level Description Language (LDL)* allows you to create.
 
 You can buy *Quake* online from the following places. Please note that ***AudioQuake* does not support the mission packs**.
 
@@ -93,16 +105,4 @@ You can buy *Quake* online from the following places. Please note that ***AudioQ
     * [*Quake Mission Pack 1: Scourge of Armagon*](https://store.steampowered.com/app/9040/QUAKE_Mission_Pack_1_Scourge_of_Armagon/)
     * [*Quake Mission Pack 2: Dissolution of Eternity*](https://store.steampowered.com/app/9030/QUAKE_Mission_Pack_2_Dissolution_of_Eternity/)
 -->
-
-### Playing *Open Quartz* instead of *Quake*
-
-However, *AudioQuake* does come with the Open Source and Free Software *Open Quartz* data pack. It's similar in spirit to *Quake* in that it's a first-person shooter and aims to be a drop-in replacement for *Quake*, but it sounds (and looks) quite different and is a game in its own right.
-
-You can start playing *Open Quartz* with all the accesibility features that *AudioQuake* provides out-of-the box. You can also make your own maps with *Level Description Language (LDL)* using the *Open Quartz* textures and even some high-contrast textures, courtessy of *Prototype.wad* too.
-
-Whilst using *Open Quartz* supports custom mapping and even some mods originally made for *AudioQuake*, there are some limitations at the moment: *Open Quartz* doesn't have replacements for some of *Quake*'s data, so you will find that some maps and mods won't work.
-
-Currently at least one of the *Level Description Language (LDL)* maps requires some of this data and won't run under *Open Quartz*.
-
-<!-- FIXME -->
 

--- a/audioquake/manuals/user-manual-part08-gfdl-1.2.md
+++ b/audioquake/manuals/user-manual-part08-gfdl-1.2.md
@@ -1,4 +1,4 @@
-### GNU Free Documentation License
+## GNU Free Documentation License
 
 Version 1.2, November 2002
 

--- a/audioquake/manuals/user-manual-part08-gfdl-1.2.md
+++ b/audioquake/manuals/user-manual-part08-gfdl-1.2.md
@@ -1,0 +1,394 @@
+### GNU Free Documentation License
+
+Version 1.2, November 2002
+
+      Copyright (C) 2000,2001,2002  Free Software Foundation, Inc.
+      51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+      
+      Everyone is permitted to copy and distribute verbatim copies
+      of this license document, but changing it is not allowed.
+
+**0. PREAMBLE**
+
+The purpose of this License is to make a manual, textbook, or other
+functional and useful document "free" in the sense of freedom: to
+assure everyone the effective freedom to copy and redistribute it,
+with or without modifying it, either commercially or noncommercially.
+Secondarily, this License preserves for the author and publisher a way
+to get credit for their work, while not being considered responsible
+for modifications made by others.
+
+This License is a kind of "copyleft", which means that derivative
+works of the document must themselves be free in the same sense. It
+complements the GNU General Public License, which is a copyleft
+license designed for free software.
+
+We have designed this License in order to use it for manuals for free
+software, because free software needs free documentation: a free
+program should come with manuals providing the same freedoms that the
+software does. But this License is not limited to software manuals; it
+can be used for any textual work, regardless of subject matter or
+whether it is published as a printed book. We recommend this License
+principally for works whose purpose is instruction or reference.
+
+**1. APPLICABILITY AND DEFINITIONS**
+
+This License applies to any manual or other work, in any medium, that
+contains a notice placed by the copyright holder saying it can be
+distributed under the terms of this License. Such a notice grants a
+world-wide, royalty-free license, unlimited in duration, to use that
+work under the conditions stated herein. The "Document", below, refers
+to any such manual or work. Any member of the public is a licensee,
+and is addressed as "you". You accept the license if you copy, modify
+or distribute the work in a way requiring permission under copyright
+law.
+
+A "Modified Version" of the Document means any work containing the
+Document or a portion of it, either copied verbatim, or with
+modifications and/or translated into another language.
+
+A "Secondary Section" is a named appendix or a front-matter section of
+the Document that deals exclusively with the relationship of the
+publishers or authors of the Document to the Document's overall
+subject (or to related matters) and contains nothing that could fall
+directly within that overall subject. (Thus, if the Document is in
+part a textbook of mathematics, a Secondary Section may not explain
+any mathematics.) The relationship could be a matter of historical
+connection with the subject or with related matters, or of legal,
+commercial, philosophical, ethical or political position regarding
+them.
+
+The "Invariant Sections" are certain Secondary Sections whose titles
+are designated, as being those of Invariant Sections, in the notice
+that says that the Document is released under this License. If a
+section does not fit the above definition of Secondary then it is not
+allowed to be designated as Invariant. The Document may contain zero
+Invariant Sections. If the Document does not identify any Invariant
+Sections then there are none.
+
+The "Cover Texts" are certain short passages of text that are listed,
+as Front-Cover Texts or Back-Cover Texts, in the notice that says that
+the Document is released under this License. A Front-Cover Text may be
+at most 5 words, and a Back-Cover Text may be at most 25 words.
+
+A "Transparent" copy of the Document means a machine-readable copy,
+represented in a format whose specification is available to the
+general public, that is suitable for revising the document
+straightforwardly with generic text editors or (for images composed of
+pixels) generic paint programs or (for drawings) some widely available
+drawing editor, and that is suitable for input to text formatters or
+for automatic translation to a variety of formats suitable for input
+to text formatters. A copy made in an otherwise Transparent file
+format whose markup, or absence of markup, has been arranged to thwart
+or discourage subsequent modification by readers is not Transparent.
+An image format is not Transparent if used for any substantial amount
+of text. A copy that is not "Transparent" is called "Opaque".
+
+Examples of suitable formats for Transparent copies include plain
+ASCII without markup, Texinfo input format, LaTeX input format, SGML
+or XML using a publicly available DTD, and standard-conforming simple
+HTML, PostScript or PDF designed for human modification. Examples of
+transparent image formats include PNG, XCF and JPG. Opaque formats
+include proprietary formats that can be read and edited only by
+proprietary word processors, SGML or XML for which the DTD and/or
+processing tools are not generally available, and the
+machine-generated HTML, PostScript or PDF produced by some word
+processors for output purposes only.
+
+The "Title Page" means, for a printed book, the title page itself,
+plus such following pages as are needed to hold, legibly, the material
+this License requires to appear in the title page. For works in
+formats which do not have any title page as such, "Title Page" means
+the text near the most prominent appearance of the work's title,
+preceding the beginning of the body of the text.
+
+A section "Entitled XYZ" means a named subunit of the Document whose
+title either is precisely XYZ or contains XYZ in parentheses following
+text that translates XYZ in another language. (Here XYZ stands for a
+specific section name mentioned below, such as "Acknowledgements",
+"Dedications", "Endorsements", or "History".) To "Preserve the Title"
+of such a section when you modify the Document means that it remains a
+section "Entitled XYZ" according to this definition.
+
+The Document may include Warranty Disclaimers next to the notice which
+states that this License applies to the Document. These Warranty
+Disclaimers are considered to be included by reference in this
+License, but only as regards disclaiming warranties: any other
+implication that these Warranty Disclaimers may have is void and has
+no effect on the meaning of this License.
+
+**2. VERBATIM COPYING**
+
+You may copy and distribute the Document in any medium, either
+commercially or noncommercially, provided that this License, the
+copyright notices, and the license notice saying this License applies
+to the Document are reproduced in all copies, and that you add no
+other conditions whatsoever to those of this License. You may not use
+technical measures to obstruct or control the reading or further
+copying of the copies you make or distribute. However, you may accept
+compensation in exchange for copies. If you distribute a large enough
+number of copies you must also follow the conditions in section 3.
+
+You may also lend copies, under the same conditions stated above, and
+you may publicly display copies.
+
+**3. COPYING IN QUANTITY**
+
+If you publish printed copies (or copies in media that commonly have
+printed covers) of the Document, numbering more than 100, and the
+Document's license notice requires Cover Texts, you must enclose the
+copies in covers that carry, clearly and legibly, all these Cover
+Texts: Front-Cover Texts on the front cover, and Back-Cover Texts on
+the back cover. Both covers must also clearly and legibly identify you
+as the publisher of these copies. The front cover must present the
+full title with all words of the title equally prominent and visible.
+You may add other material on the covers in addition. Copying with
+changes limited to the covers, as long as they preserve the title of
+the Document and satisfy these conditions, can be treated as verbatim
+copying in other respects.
+
+If the required texts for either cover are too voluminous to fit
+legibly, you should put the first ones listed (as many as fit
+reasonably) on the actual cover, and continue the rest onto adjacent
+pages.
+
+If you publish or distribute Opaque copies of the Document numbering
+more than 100, you must either include a machine-readable Transparent
+copy along with each Opaque copy, or state in or with each Opaque copy
+a computer-network location from which the general network-using
+public has access to download using public-standard network protocols
+a complete Transparent copy of the Document, free of added material.
+If you use the latter option, you must take reasonably prudent steps,
+when you begin distribution of Opaque copies in quantity, to ensure
+that this Transparent copy will remain thus accessible at the stated
+location until at least one year after the last time you distribute an
+Opaque copy (directly or through your agents or retailers) of that
+edition to the public.
+
+It is requested, but not required, that you contact the authors of the
+Document well before redistributing any large number of copies, to
+give them a chance to provide you with an updated version of the
+Document.
+
+**4. MODIFICATIONS**
+
+You may copy and distribute a Modified Version of the Document under
+the conditions of sections 2 and 3 above, provided that you release
+the Modified Version under precisely this License, with the Modified
+Version filling the role of the Document, thus licensing distribution
+and modification of the Modified Version to whoever possesses a copy
+of it. In addition, you must do these things in the Modified Version:
+
+-   **A.** Use in the Title Page (and on the covers, if any) a title
+    distinct from that of the Document, and from those of previous
+    versions (which should, if there were any, be listed in the
+    History section of the Document). You may use the same title as a
+    previous version if the original publisher of that version
+    gives permission.
+-   **B.** List on the Title Page, as authors, one or more persons or
+    entities responsible for authorship of the modifications in the
+    Modified Version, together with at least five of the principal
+    authors of the Document (all of its principal authors, if it has
+    fewer than five), unless they release you from this requirement.
+-   **C.** State on the Title page the name of the publisher of the
+    Modified Version, as the publisher.
+-   **D.** Preserve all the copyright notices of the Document.
+-   **E.** Add an appropriate copyright notice for your modifications
+    adjacent to the other copyright notices.
+-   **F.** Include, immediately after the copyright notices, a license
+    notice giving the public permission to use the Modified Version
+    under the terms of this License, in the form shown in the
+    Addendum below.
+-   **G.** Preserve in that license notice the full lists of Invariant
+    Sections and required Cover Texts given in the Document's
+    license notice.
+-   **H.** Include an unaltered copy of this License.
+-   **I.** Preserve the section Entitled "History", Preserve its
+    Title, and add to it an item stating at least the title, year, new
+    authors, and publisher of the Modified Version as given on the
+    Title Page. If there is no section Entitled "History" in the
+    Document, create one stating the title, year, authors, and
+    publisher of the Document as given on its Title Page, then add an
+    item describing the Modified Version as stated in the
+    previous sentence.
+-   **J.** Preserve the network location, if any, given in the
+    Document for public access to a Transparent copy of the Document,
+    and likewise the network locations given in the Document for
+    previous versions it was based on. These may be placed in the
+    "History" section. You may omit a network location for a work that
+    was published at least four years before the Document itself, or
+    if the original publisher of the version it refers to
+    gives permission.
+-   **K.** For any section Entitled "Acknowledgements" or
+    "Dedications", Preserve the Title of the section, and preserve in
+    the section all the substance and tone of each of the contributor
+    acknowledgements and/or dedications given therein.
+-   **L.** Preserve all the Invariant Sections of the Document,
+    unaltered in their text and in their titles. Section numbers or
+    the equivalent are not considered part of the section titles.
+-   **M.** Delete any section Entitled "Endorsements". Such a section
+    may not be included in the Modified Version.
+-   **N.** Do not retitle any existing section to be Entitled
+    "Endorsements" or to conflict in title with any Invariant Section.
+-   **O.** Preserve any Warranty Disclaimers.
+
+If the Modified Version includes new front-matter sections or
+appendices that qualify as Secondary Sections and contain no material
+copied from the Document, you may at your option designate some or all
+of these sections as invariant. To do this, add their titles to the
+list of Invariant Sections in the Modified Version's license notice.
+These titles must be distinct from any other section titles.
+
+You may add a section Entitled "Endorsements", provided it contains
+nothing but endorsements of your Modified Version by various
+parties--for example, statements of peer review or that the text has
+been approved by an organization as the authoritative definition of a
+standard.
+
+You may add a passage of up to five words as a Front-Cover Text, and a
+passage of up to 25 words as a Back-Cover Text, to the end of the list
+of Cover Texts in the Modified Version. Only one passage of
+Front-Cover Text and one of Back-Cover Text may be added by (or
+through arrangements made by) any one entity. If the Document already
+includes a cover text for the same cover, previously added by you or
+by arrangement made by the same entity you are acting on behalf of,
+you may not add another; but you may replace the old one, on explicit
+permission from the previous publisher that added the old one.
+
+The author(s) and publisher(s) of the Document do not by this License
+give permission to use their names for publicity for or to assert or
+imply endorsement of any Modified Version.
+
+**5. COMBINING DOCUMENTS**
+
+You may combine the Document with other documents released under this
+License, under the terms defined in section 4 above for modified
+versions, provided that you include in the combination all of the
+Invariant Sections of all of the original documents, unmodified, and
+list them all as Invariant Sections of your combined work in its
+license notice, and that you preserve all their Warranty Disclaimers.
+
+The combined work need only contain one copy of this License, and
+multiple identical Invariant Sections may be replaced with a single
+copy. If there are multiple Invariant Sections with the same name but
+different contents, make the title of each such section unique by
+adding at the end of it, in parentheses, the name of the original
+author or publisher of that section if known, or else a unique number.
+Make the same adjustment to the section titles in the list of
+Invariant Sections in the license notice of the combined work.
+
+In the combination, you must combine any sections Entitled "History"
+in the various original documents, forming one section Entitled
+"History"; likewise combine any sections Entitled "Acknowledgements",
+and any sections Entitled "Dedications". You must delete all sections
+Entitled "Endorsements."
+
+**6. COLLECTIONS OF DOCUMENTS**
+
+You may make a collection consisting of the Document and other
+documents released under this License, and replace the individual
+copies of this License in the various documents with a single copy
+that is included in the collection, provided that you follow the rules
+of this License for verbatim copying of each of the documents in all
+other respects.
+
+You may extract a single document from such a collection, and
+distribute it individually under this License, provided you insert a
+copy of this License into the extracted document, and follow this
+License in all other respects regarding verbatim copying of that
+document.
+
+**7. AGGREGATION WITH INDEPENDENT WORKS**
+
+A compilation of the Document or its derivatives with other separate
+and independent documents or works, in or on a volume of a storage or
+distribution medium, is called an "aggregate" if the copyright
+resulting from the compilation is not used to limit the legal rights
+of the compilation's users beyond what the individual works permit.
+When the Document is included in an aggregate, this License does not
+apply to the other works in the aggregate which are not themselves
+derivative works of the Document.
+
+If the Cover Text requirement of section 3 is applicable to these
+copies of the Document, then if the Document is less than one half of
+the entire aggregate, the Document's Cover Texts may be placed on
+covers that bracket the Document within the aggregate, or the
+electronic equivalent of covers if the Document is in electronic form.
+Otherwise they must appear on printed covers that bracket the whole
+aggregate.
+
+**8. TRANSLATION**
+
+Translation is considered a kind of modification, so you may
+distribute translations of the Document under the terms of section 4.
+Replacing Invariant Sections with translations requires special
+permission from their copyright holders, but you may include
+translations of some or all Invariant Sections in addition to the
+original versions of these Invariant Sections. You may include a
+translation of this License, and all the license notices in the
+Document, and any Warranty Disclaimers, provided that you also include
+the original English version of this License and the original versions
+of those notices and disclaimers. In case of a disagreement between
+the translation and the original version of this License or a notice
+or disclaimer, the original version will prevail.
+
+If a section in the Document is Entitled "Acknowledgements",
+"Dedications", or "History", the requirement (section 4) to Preserve
+its Title (section 1) will typically require changing the actual
+title.
+
+**9. TERMINATION**
+
+You may not copy, modify, sublicense, or distribute the Document
+except as expressly provided for under this License. Any other attempt
+to copy, modify, sublicense or distribute the Document is void, and
+will automatically terminate your rights under this License. However,
+parties who have received copies, or rights, from you under this
+License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+**10. FUTURE REVISIONS OF THIS LICENSE**
+
+The Free Software Foundation may publish new, revised versions of the
+GNU Free Documentation License from time to time. Such new versions
+will be similar in spirit to the present version, but may differ in
+detail to address new problems or concerns. See
+https://www.gnu.org/licenses/.
+
+Each version of the License is given a distinguishing version number.
+If the Document specifies that a particular numbered version of this
+License "or any later version" applies to it, you have the option of
+following the terms and conditions either of that specified version or
+of any later version that has been published (not as a draft) by the
+Free Software Foundation. If the Document does not specify a version
+number of this License, you may choose any version ever published (not
+as a draft) by the Free Software Foundation.
+
+### [How to use this License for your documents]()
+
+To use this License in a document you have written, include a copy of
+the License in the document and put the following copyright and
+license notices just after the title page:
+
+      Copyright (c)  YEAR  YOUR NAME.
+      Permission is granted to copy, distribute and/or modify this document
+      under the terms of the GNU Free Documentation License, Version 1.2
+      or any later version published by the Free Software Foundation;
+      with no Invariant Sections, no Front-Cover Texts, and no Back-Cover
+      Texts.  A copy of the license is included in the section entitled "GNU
+      Free Documentation License".
+
+If you have Invariant Sections, Front-Cover Texts and Back-Cover
+Texts, replace the "with...Texts." line with this:
+
+      with the Invariant Sections being LIST THEIR TITLES, with the
+      Front-Cover Texts being LIST, and with the Back-Cover Texts being LIST.
+
+If you have Invariant Sections without Cover Texts, or some other
+combination of the three, merge those two alternatives to suit the
+situation.
+
+If your document contains nontrivial examples of program code, we
+recommend releasing these examples in parallel under your choice of
+free software license, such as the GNU General Public License, to
+permit their use in free software.

--- a/audioquake/qmodlib.py
+++ b/audioquake/qmodlib.py
@@ -66,8 +66,8 @@ class InstalledQMOD():
 		config = ConfigParser()
 		config.read_file(open(ini_path))
 
-		self.watch_config = config['general']['watch_config']
-		self.watch_autoexec = config['general']['watch_autoexec']
+		self.watch_config = config['general'].getboolean('watch_config')
+		self.watch_autoexec = config['general'].getboolean('watch_autoexec')
 
 		self.mod_path = path
 

--- a/build-giants.py
+++ b/build-giants.py
@@ -58,7 +58,7 @@ def compile_gamecode():
 
 def make_gamecode(progs):
 	try_to_run(
-		(os.path.join(Config.dir_qc, Config.bin_zqcc), '-progs', progs),
+		(Config.dir_qc / Config.bin_zqcc, '-progs', progs),
 		'failed to compile gamecode file: ' + progs)
 
 
@@ -74,33 +74,30 @@ def rename_qutils():
 				os.path.join(root, name.lower()))
 
 
-def patch_map_tools():
-	patches = {
-		'Makefile': os.path.join(Config.dir_patches, 'makefile.patch'),
-		'writebsp.c': os.path.join(Config.dir_patches, 'writebsp.c.patch'),
-		'qbsp.c': os.path.join(Config.dir_patches, 'qbsp.c.patch')
-	}
-
+def _patch_map_tools_core(patches):
 	for title, patch_file in patches.items():
 		patch_set = patch.fromfile(patch_file)
 		if not patch_set.apply(root=Config.dir_qbsp):
-			raise Exception('Patch', patch_file, 'failed.')
+			raise Exception(f'Patch "{patch_file.name}" failed.')
+
+
+def patch_map_tools_all():
+	patches_for_all_platforms = {
+		'Makefile': Config.dir_patches / 'makefile.patch',
+		'writebsp.c': Config.dir_patches / 'writebsp.c.patch',
+		'qbsp.c': Config.dir_patches / 'qbsp.c.patch'
+	}
+	_patch_map_tools_core(patches_for_all_platforms)
 
 
 def patch_map_tools_windows():
 	windows_patches = {
-		'qbsp.mak': os.path.join(Config.dir_patches, 'qbsp.mak.patch'),
-		'light.mak': os.path.join(Config.dir_patches, 'light.mak.patch'),
-		'vis.mak': os.path.join(Config.dir_patches, 'vis.mak.patch'),
-		'bspinfo.mak': os.path.join(Config.dir_patches, 'bspinfo.mak.patch')
+		'qbsp.mak': Config.dir_patches / 'qbsp.mak.patch',
+		'light.mak': Config.dir_patches / 'light.mak.patch',
+		'vis.mak': Config.dir_patches / 'vis.mak.patch',
+		'bspinfo.mak': Config.dir_patches / 'bspinfo.mak.patch'
 	}
-
-	# FIXME DRY
-	for title, patch_file in windows_patches.items():
-		print('Patching', title)
-		patch_set = patch.fromfile(patch_file)
-		if not patch_set.apply(root=Config.dir_quake_tools):
-			raise Exception('Patch', patch_file, 'failed.')
+	_patch_map_tools_core(windows_patches)
 
 
 def compile_map_tools():
@@ -149,7 +146,7 @@ def build_giants():
 	rename_qutils()
 
 	print('Patching the Quake map tools')
-	patch_map_tools()
+	patch_map_tools_all()
 	doset_only(windows=patch_map_tools_windows)
 
 	print('Compiling the Quake map tools')

--- a/build-giants.py
+++ b/build-giants.py
@@ -74,20 +74,20 @@ def rename_qutils():
 				os.path.join(root, name.lower()))
 
 
-def _patch_map_tools_core(patches):
+def _patch_map_tools_core(patches, root):
 	for title, patch_file in patches.items():
 		patch_set = patch.fromfile(patch_file)
-		if not patch_set.apply(root=Config.dir_qbsp):
-			raise Exception(f'Patch "{patch_file.name}" failed.')
+		if not patch_set.apply(root=root):
+			raise Exception(f'Patch "{patch_file.name}": OK')
 
 
 def patch_map_tools_all():
-	patches_for_all_platforms = {
+	patches_all = {
 		'Makefile': Config.dir_patches / 'makefile.patch',
 		'writebsp.c': Config.dir_patches / 'writebsp.c.patch',
 		'qbsp.c': Config.dir_patches / 'qbsp.c.patch'
 	}
-	_patch_map_tools_core(patches_for_all_platforms)
+	_patch_map_tools_core(patches_all, Config.dir_qbsp)
 
 
 def patch_map_tools_windows():
@@ -97,7 +97,7 @@ def patch_map_tools_windows():
 		'vis.mak': Config.dir_patches / 'vis.mak.patch',
 		'bspinfo.mak': Config.dir_patches / 'bspinfo.mak.patch'
 	}
-	_patch_map_tools_core(windows_patches)
+	_patch_map_tools_core(windows_patches, Config.dir_quake_tools)
 
 
 def compile_map_tools():

--- a/build-giants.py
+++ b/build-giants.py
@@ -5,7 +5,7 @@ import os
 import patch_ng as patch
 
 from buildlib import Config, \
-	comeback, check_platform, do_something, only_on, make, die, try_to_run
+	comeback, check_platform, doset, doset_only, make, die, try_to_run
 
 
 #
@@ -133,12 +133,12 @@ def build_giants():
 	print('Building', stuff + '...')
 
 	print('Compiling zquake')
-	do_something(
+	doset(
 		mac=compile_zquake,
 		windows=compile_zquake_windows)
 
 	print('Compiling zqcc')
-	do_something(
+	doset(
 		mac=compile_zqcc,
 		windows=compile_zqcc_windows)
 
@@ -150,10 +150,10 @@ def build_giants():
 
 	print('Patching the Quake map tools')
 	patch_map_tools()
-	only_on(windows=patch_map_tools_windows)
+	doset_only(windows=patch_map_tools_windows)
 
 	print('Compiling the Quake map tools')
-	do_something(
+	doset(
 		mac=compile_map_tools,
 		windows=compile_map_tools_windows)
 

--- a/ldl/tutorial.md
+++ b/ldl/tutorial.md
@@ -1,8 +1,8 @@
-# What is Level Description Language?
+## What is Level Description Language?
 
 The AGRIP *Level Description Language*, or LDL, is a text-based format that allows people to easily describe 3D spaces. LDL is currently aimed at blind gamers who want to make maps for *Quake*. This is a preliminary concept release, so it's important to say what it does, doesn't and might do.
 
-## Digital archaeology note from 2020
+### Digital archaeology note from 2020
 
 OK, whilst *Quake* is now ancient (but still a milestone in gaming), the techniques here could be applied to newer engines in much the same way; would love to see, or even help, that happen. In the meantime, you can still use this to make and explore your own somewhat-simplistically-shaped-but-nonetheless-3D worlds! :-)
 
@@ -15,7 +15,7 @@ There are, however, a couple of new features that did get added...
 
 If you're building maps via the *AudioQuake and LDL Launcher*, it will build all versions of your map, for you to play in either *Open Quartz* or *Quake*. It'll also let you play the map in any mode after building, but if you want to get to it in-game later, be sure to include "hc" at the end of the map name if you want to play the high-contrast version.
 
-## Before LDL
+### Before LDL
 
 How would one go about making maps for *Quake* before LDL? If you just want to find out how to use LDL you can skip this section, however it does provide useful background information on the area that we are now working on providing access to.
 
@@ -45,7 +45,7 @@ How would one go about making maps for *Quake* before LDL? If you just want to f
 
      This helps the engine work out which parts of the map don't need to be displayed depending on the viewpoint of the player, thus saving the engine from having to draw everything in the map at all times and speeding things up dramatically.
 
-## How does LDL work?
+### How does LDL work?
 
 The operating principle of LDL is that we start with as high-level a description as possible and gradually transform it, by filling in the details, into a low-level description suitable for compiling with the standard *Quake* map tools. This allows you to talk in terms of rooms and connections between them, whereas the map tools at the bottom of the chain want to know about scary things like intersecting 3D planes.
 
@@ -63,9 +63,9 @@ The workflow for using LDL is as follows.
 
    If it doesn't work, there could be an error in your XML file (or a bug in the LDL code, which we implore you to report!) Go back to the XML, try to fix the problem (error messages will try to help you do this) and try again.
 
-   If/when it does work, you will then be able to play the map in **AudioQuake**.
+   If/when it does work, you will then be able to play the map in *AudioQuake*.
 
-## What can and can't it do?
+### What can and can't it do?
 
 The test release is focused on describing the spaces and making simple deathmatch maps. It does the following.
 
@@ -81,7 +81,9 @@ It does have some limitations, though…
 
 * It can't make connections between rooms that are not next to each other—that is to say you need to specify the corridors that connect between rooms (as rooms themselves, which they are—they’re usually just longer and thinner).
 
-## Possible and blue sky features
+* It doesn't support: rooms containing water/slime/lava; switches/buttons and doors that require keys—though all of these could be added rather easily.
+
+### Possible and blue sky features
 
 Here are some features that would be fairly possible given the current foundations…
 
@@ -95,17 +97,17 @@ Some limitations of the system that may be addressed in future include the inabi
 
 For now, however, there's a great deal you *can* do—as we hope the tutorial below will show.
 
-## Running LDL
+### Running LDL
 
-LDL comes as part of **AudioQuake**—you can access it via the launcher's "Map" tab. There you can open a map file you're working on (or one of the tutorial examples that match the tutorial steps below) and build and play it.
+LDL comes as part of *AudioQuake*—you can access it via the launcher's "Map" tab. There you can open a map file you're working on (or one of the tutorial examples that match the tutorial steps below) and build and play it.
 
-If you clone the AGRIP code repo from GitHub and use a Mac, you can also use the LDL command-line tools. Info on how to do that is provided in the READMEs and in the help for the LDL program itself.
+If you clone the AGRIP code repo from GitHub, you can also use the LDL command-line tools. Info on how to do that is provided in the READMEs and in the help for the LDL program itself.
 
-# Making maps with LDL
+## Making maps with LDL
 
-This section is a tutorial on making levels with LDL. It assumes you've got **AudioQuake** and you have a text editor set up that can edit XML files.
+This section is a tutorial on making levels with LDL. It assumes you've got *AudioQuake* and you have a text editor set up that can edit XML files.
 
-## Basic concepts
+### Basic concepts
 
 Before you start, please be aware of the following.
 
@@ -119,9 +121,9 @@ Before you start, please be aware of the following.
 
 * Unless you add enough deathmatch player start points, you will have great problems running the map in deathmatch mode, as all of the bots will try to spawn out of one start point. You'll read later how to add start points.
 
-   For now, be aware that the **AudioQuake** launcher and the LDL command-line tools open your maps in non-deathmatch mode. For that to work, you have to have one—and only one—`info_player_start` entity in your map. Again, more on this later.
+   For now, be aware that the *AudioQuake* launcher and the LDL command-line tools open your maps in non-deathmatch mode. For that to work, you have to have one—and only one—`info_player_start` entity in your map. Again, more on this later.
 
-## Example 1: Hello, world!
+### Example 1: Hello, world!
 
 Let's start with a very simple example map.
 
@@ -142,9 +144,12 @@ That's the simplest map you can make with LDL that can be played. Let’s take a
 This starts our map off; it's an XML *element* called "map". Elements are written inside angle-brackets and may also have additional information specified about them by way of *attributes*. The map element has two attributes:
 
 * A name, which is "test" in this case. This is what is displayed in the console when the map is loaded.
+
 * A *style*, which is "base" in this case. This affects lighting, texturing, sounds and key types used in the map.
 
   The style of a map is used to denote which texture, lighting and—to some extent—sound scheme is applied. Currently, LDL supports "base" and "medieval".
+
+  When building a map, you can choose whether you want to use textures from *Quake* (if you bought and installed the data files), *Open Quartz* or a high-contrast texture set (from *Prototype.wad*). Each texture set supports both "base" and "medieval" styles.
 
 As well as having attributes, an element can contain other elements. When we get to the end of the map, we must *close* the map element with `</map>` (this is much like the starting tag, but the first thing within the angle-brackets is a forward slash).
 
@@ -186,7 +191,7 @@ Try running this map through the LDL system. As part of the conversion to a *.ma
 
 Once LDL and the *Quake* map tools have finished processing, the game will start and you should be in a medium-sized room with not much else going on.
 
-## Example 2: Room sizes
+### Example 2: Room sizes
 
 When you don't specify a size for the room, it’s made "medium" by default. Let's try specifying a different size for the room. Here’s the whole map, with the size altered.
 
@@ -202,7 +207,7 @@ Try saving it and running it. You should find that you can walk much further in 
 
 There are several room sizes: vsmall, small, med, big, large, vlarge, xlarge, huge, vhuge and xhuge.
 
-## Example 3: Invalid room size
+### Example 3: Invalid room size
 
 If you were to specify a size that is not valid, you would get an error message. Try that now, with the following input.
 
@@ -214,7 +219,7 @@ If you were to specify a size that is not valid, you would get an error message.
 </map>
 ```
 
-## Example 4: Room sizes in each dimension—or: corridors!
+### Example 4: Room sizes in each dimension—or: corridors!
 
 Because the room is a 3D object, you can also specify its size in the 3 dimensions: width, depth and height. Different programs and systems use these terms differently, so to avoid any possible confusion, we'll define them as LDL uses them here.
 
@@ -240,7 +245,7 @@ One last thing to note about room sizes in LDL is that the sizes in the width an
 
 If you really really want to make your room exactly cube-shaped, you can—use any of the following for your room's size attribute "vsmall vsmall small", "small small big", "med med vlarge", "big big xlarge", "large large huge", "xlarge xlarge vhuge" or "huge huge xhuge".
 
-### XML errors
+#### XML errors
 
 We will now purposely introduce an error into the file, so that you can experience the effects and the solution, which will hopefully help you fix errors in your own maps, should they occur. Because XML files are very structured in nature, in our case with rooms inside maps and items inside rooms, they are sensitive to errors such as omitted information.
 
@@ -266,7 +271,7 @@ to
 
 Now we've just got the start of the item tag. What the computer reads next it will assume is meant to be inside the item (which doesn't make any sense to us of course, as items, like weapons, spawn-points or power-ups can't actually contain anything). On reading the `</room>` tag, the computer will realise there is a problem as the thing we've effectively tried to put inside the item is the end of the room. Clearly there has been an error (we know this to be a missing `</item>` or a missing forward-slash before the end of the `<item>` tag) but the computer doesn't have the brains to work out what that error is, so it will just tell you about it.
 
-## Example 5: Connecting rooms
+### Example 5: Connecting rooms
 
 Now to make the map a bit more interesting! We will create two rooms and link them.
 
@@ -284,7 +289,7 @@ There are now 2 rooms, "start" and "other", which are linked by a door. LDL plac
 
 This is the same as the way directions work in most Interactive Fiction games. If it helps, you could imagine being above the map and looking down on it as if it was an, erm, map. Then, north would be to the top, south to the bottom, west to the left and east to the right. (Both ways of imagining the situation are the same—hopefully at least one will be helpful.)
 
-## Example 6: Connecting rooms the other way around
+### Example 6: Connecting rooms the other way around
 
 Above we specified the connection inside the room "start". It works the other way around too, so that was exactly the same as if we had said the following instead.
 
@@ -301,7 +306,7 @@ Above we specified the connection inside the room "start". It works the other wa
 
 Run the map through LDL and experiment. The room you start in will lead onto another room, which you will access via a door that is directly in front of you when you start (LDL places doors in the middle of the wall they're on and at ground level by default—more on this later).
 
-## Example 7: Items and monsters
+### Example 7: Items and monsters
 
 Let's make the last map a little more interesting. We’ll move the player start point to the south end of the start room, add a shiny weapon for you to pick up and, in the northern room, place a monster for you to use it on.
 
@@ -320,7 +325,7 @@ Let's make the last map a little more interesting. We’ll move the player start
 
 As this map is in the medieval style, you may have noticed the door making a different sound when it opened. The texturing and lighting of the level will also be different and more appropriate to the medieval style (meaning that sighted games might like to play your map too).
 
-### Compass points
+#### Compass points
 
 Currently the way to specify the location of items within rooms is to use compass points. When you specify the location of an item, it works in a similar way to connections above.
 
@@ -328,7 +333,7 @@ We plan to implement other ways to specify locations soon but, for now, you can 
 
 Currently we don't provide a mechanism to control at what height within the room that items will be placed.
 
-## Example 8: Making deathmatch maps
+### Example 8: Making deathmatch maps
 
 So far we have made some simple maps that are designed for the single-player version of the game. Single-player maps have one `info_player_start`. Deathmatch maps require many `info_player_deathmatch` spawn points. If you only have one `info_player_deathmatch`, all of the bots and clients will spawn from that one point and keep telefragging each other, causing the level to be over quite quickly! Let's make a very simple deathmatch level, suitable for a small number of players. This time, we’ll construct the map step by step before giving the whole XML file that you can copy and paste.
 
@@ -427,7 +432,7 @@ When you run the normal LDL compilation and test scripts on this map, you'll be 
 
 Hopefully you have now had a pleasant deathmatch experience in your own map\!
 
-### Co-operative maps
+#### Co-operative maps
 
 These are similar to deathmatch maps in that you need to include more than one spawn point. However, the spawn points are usually situated together at the "start" of the map and must be of type `info_player_coop` (you can have as many as you like).
 
@@ -437,7 +442,7 @@ Remember, to play a co-op map, set the console variables as follows.
     coop 1
     map mapname
 
-## Example 9: Connections via stairs
+### Example 9: Connections via stairs
 
 We'll now revisit our previous example of two connected rooms. So far we’re able to specify that two rooms are linked by making a connection from one to another, which may be in the form of a door or just a hole in the connecting wall. By default the connection is made in the middle of the wall at floor level.
 
@@ -465,7 +470,7 @@ Have a go running this map: walk straight forward and you will find some stairs.
 
 Try changing the value of the `elevtype` attribute for the connection to "plat" and try the map again.
 
-### Example 10: Even more positioning
+#### Example 10: Even more positioning
 
 Try changing the `pos` to "tl" from "t" and you'll find that you have to move to the left/west to find the stairs up to room "other".
 
@@ -485,7 +490,7 @@ Once you're happy with this, you might be asking how you can reposition the conn
 </map>
 ```
 
-### Example 11: Making connection corridors
+#### Example 11: Making connection corridors
 
 Say you have two rooms, at different heights and you want to make a connection between them, in the form of a corridor with stairs in it. This is an example of how you might go about doing so.
 
@@ -520,13 +525,13 @@ We've added an attribute, `extent`, to the connection and given it the size "+".
 
 You can specify sizes ("small", "med" and so on) in the `extent` attribute, as you can with rooms. You can also mix and match, so saying `extent='+ med'` means "take up all available width, but be only medium-sized in depth". Bear in mind that if the corridor was going from east to west (or vice-verse) these would be reversed (which is why it's often easier to just use "+" as the size specifier).
 
-### Vertical connections to other rooms
+#### Vertical connections to other rooms
 
 It is possible for you to position one room entirely on top of or underneath another and link them with connections as discussed earlier, though you'd use "u" (up) and "d" (down) to identify the walls the connections lie on. Currently it is not possible to make elevation devices for these connections (e.g. a plat).
 
 Another thing that could be done in future is supporting teleporters, so you could move between rooms instantaneously.
 
-# Some golden rules
+## Some golden rules
 
 * Always write well-formed XML. This means closing tags and quotes properly, or you will get a "parse error".
 
@@ -542,21 +547,41 @@ Another thing that could be done in future is supporting teleporters, so you cou
 
 * When assigning sizes to things like rooms, we may say "large" or, if we want to be more precise, specify the size in each of the 3 dimensions of width, depth and height, separated by spaces—e.g. "medium large medium". When facing north in a room, its width is the distance from your left to your right; its depth is the distance from back to front and its height is vertical distance between its floor and ceiling.
 
-# Reference information
+## Tricks and treats
 
-## The style file—automating texturing and lighting
+### The style file: automating texturing and lighting
 
 One helpful feature of LDL is that it automates the process of texturing and lighting a map. This often tedious stage involves applying appropriate pictures to the walls of the brushes (solid shapes) in the map and also adding light entities in the right places to create the desired "look". Though LDL cannot compete with a sighted human on artistic grounds, it goes a long way and provides somewhat atmospheric lighting for sighted players.
 
-The file *style.xml* included with LDL contains information on the textures and lighting. It will be document more fully in the coming releases.
+The file "style.xml" included with LDL contains information on the textures and lighting. You can find it in the AudioQuake directory and in the code repository.
 
-## Test maps
+<!-- FIXME TODO: document it more. Can custom lighting styles be applied? -->
 
-The tutorial files (*tut*\**.xml*) are also provided for your reference and are available from the **AudioQuake** launcher.
+### Additional texturing styles
 
-If you check out the code from the repository, you will find various test maps (*test_*\**_*\**.xml* files) that provide some examples on how to use the system. The number in the name indicates which layer of the system the map is written for (remember earlier we discussed that LDL is composed of a number of layers). The layer "05" maps because the lower levels rely on absolute coordinates.
+As well as the "base" and "medieval" styles described above, you can define other texture set styles to use in different rooms (but not the map as a whole). There are already two in the "style.xml" file: "outsidelight" and "outsidedark". When applied to a room, they change the walls and ceiling to a sky texture, and the floor to a ground/grass texture.
 
-## List of entities
+These other styles can be applied to a room, but not the map itself. They don't have to define replacements for all of the textures defined by a set—if any are missing, LDL will fall back to the underlying map style ("base" or "medieval").
+
+You can define your own by editing "style.xml".
+
+### More complex layouts
+
+Whilst LDL doesn't allow for very advanced geometry, and it doesn't stop you from describing layouts that involved rooms being placed 'over the top' of each-other, this can actually be used to your advantage. In the example maps (reachable via the launcher and in the code repository), you can find an example of a layout created by the superposition of several rooms around the corners of a larger one, which makes for some interesting shapes.
+
+## Reference information
+
+### Example maps
+
+<!-- FIXME: *AudioQuake launcher* or *AudioQuake and LDL launcher* ... ? -->
+
+The tutorial files ("tut\*.xml" as covered above) are provided for your reference and are available from the *AudioQuake* launcher. You'll also find various example maps there too.
+
+If you check out the code from the repository, you will find the test maps there too. They're named like "test_0\*_\*.xml"). The number in the name indicates which layer of the system the map is written for (remember earlier we discussed that LDL is composed of a number of layers). The layer "05" maps are the ones you want—lower levels rely on absolute coordinates.
+
+<!-- FIXME: is that true re absolutes? -->
+
+### List of entities
 
 This list is also available on most *Quake* mapping websites, such as [*Quake* MAP Specs](http://www.gamers.org/dEngine/quake/QDP/qmapspec.html). Please note that most, but not all, entities are supported by the current release of LDL.
 

--- a/lib/buildlib/buildlib.py
+++ b/lib/buildlib/buildlib.py
@@ -1,4 +1,4 @@
-"""Build gubbins"""
+"""Build and cross-platform handling gubbins"""
 import os
 from pathlib import Path
 from platform import system
@@ -35,13 +35,15 @@ def _do_or_set(mac=None, windows=None):
 
 
 def doset(mac=None, windows=None):
-	if not mac or not windows:
+	if mac is None and windows is None:
 		raise MissingPlatformError()
 	return _do_or_set(mac, windows)
 
 
 def doset_only(mac=None, windows=None):
-	if (mac and windows) or (not mac and not windows):
+	if mac is None and windows is None:
+		raise MissingPlatformError()
+	if mac is not None and windows is not None:
 		raise TooManyPlatformsError()
 	return _do_or_set(mac, windows)
 

--- a/lib/buildlib/buildlib.py
+++ b/lib/buildlib/buildlib.py
@@ -7,78 +7,48 @@ import subprocess
 import traceback
 
 
-class PlatformSetError(Exception):
+#
+# Doing/setting things cross-platform
+#
+
+class MissingPlatformError(Exception):
 	pass
 
 
-class DoSomethingError(Exception):
+class TooManyPlatformsError(Exception):
 	pass
 
 
-class OnlyOnError(Exception):
-	pass
-
-
-# FIXME DRY with do_something really (just cope with types)
-def platform_set(mac=None, windows=None):
-	if not mac or not windows:
-		raise PlatformSetError()
+def _do_or_set(mac=None, windows=None):
+	def _core(thing):
+		if callable(thing):
+			return thing()
+		elif thing is not None:
+			return thing
 
 	if system() == 'Darwin':
-		return mac
+		return _core(mac)
 	elif system() == 'Windows':
-		return windows
+		return _core(windows)
 	else:
 		raise NotImplementedError
 
 
-class Config:
-	base = Path(__file__).parent.parent.parent
+def doset(mac=None, windows=None):
+	if not mac or not windows:
+		raise MissingPlatformError()
+	return _do_or_set(mac, windows)
 
-	dir_readme_licence = base
 
-	zq_repo = base / 'giants' / 'zq-repo'
-	dir_make_zqcc = zq_repo / 'zqcc'
-	dir_make_zquake = zq_repo / 'zquake'
-	dir_zquake_source = zq_repo / 'zquake' / 'source'
-	dir_qc = zq_repo / 'qc' / 'agrip'
+def doset_only(mac=None, windows=None):
+	if (mac and windows) or (not mac and not windows):
+		raise TooManyPlatformsError()
+	return _do_or_set(mac, windows)
 
-	bin_zqcc = platform_set(
-		mac=dir_make_zqcc / 'zqcc',
-		windows=dir_make_zqcc / 'Release' / 'zqcc.exe')
 
-	bin_zqgl = platform_set(
-		mac=dir_make_zquake / 'release-mac' / 'zquake-glsdl',
-		windows=dir_make_zquake / 'source' / 'Release-GL' / 'zquake-gl.exe')
-
-	bin_zqds = platform_set(
-		mac=dir_make_zquake / 'release-mac' / 'zqds',
-		windows=dir_make_zquake / 'source' / 'Release-server' / 'zqds.exe')
-
-	dir_quake_tools = base / 'giants' / 'Quake-Tools'
-	dir_qutils = dir_quake_tools / 'qutils'
-	dir_qbsp = dir_qutils / 'qbsp'
-
-	dir_ldllib = base / 'ldl' / 'ldllib'
-
-	aq = base / 'audioquake'
-	file_aq_release = aq / 'release'
-	dir_dist = aq / 'dist'
-	dir_manuals = aq / 'manuals'
-	dir_manuals_converted = aq / 'manuals-converted'
-	dir_dist_rcon = dir_dist / 'rcon'
-	dir_maps_source = aq / 'maps'
-	dir_maps_quakewad = aq / 'maps-quakewad'
-	dir_maps_freewad = aq / 'maps-freewad'
-	dir_maps_prototypewad = aq / 'maps-prototypewad'
-
-	dir_aq_data = platform_set(
-		mac=dir_dist / 'AudioQuake.app' / 'Contents' / 'MacOS',
-		windows=dir_dist / 'AudioQuake')
-
-	dir_ldl = base / 'ldl'
-	dir_patches = dir_ldl / 'patches'
-
+#
+# Build functions
+#
 
 def comeback(function):
 	def wrapper(*args, **kwargs):
@@ -146,42 +116,53 @@ def make(path, name, targets=[]):
 			_make(name, targ)
 
 
-# FIXME DRY with platform_set really (just cope with types)
-def do_something(mac=None, windows=None):
-	if not mac or not windows:
-		raise DoSomethingError()
+#
+# Configuration
+#
 
-	if system() == 'Darwin':
-		return mac()
-	elif system() == 'Windows':
-		return windows()
-	else:
-		raise NotImplementedError
+class Config:
+	base = Path(__file__).parent.parent.parent
 
+	dir_readme_licence = base
 
-# FIXME DRY with the others - only diff is the check
-def only_on(mac=None, windows=None):
-	if (mac and windows) or (not mac and not windows):
-		raise OnlyOnError()
+	zq_repo = base / 'giants' / 'zq-repo'
+	dir_make_zqcc = zq_repo / 'zqcc'
+	dir_make_zquake = zq_repo / 'zquake'
+	dir_zquake_source = zq_repo / 'zquake' / 'source'
+	dir_qc = zq_repo / 'qc' / 'agrip'
 
-	if system() == 'Darwin':
-		if mac:
-			return mac()
-	elif system() == 'Windows':
-		if windows:
-			return windows()
-	else:
-		raise NotImplementedError
+	bin_zqcc = doset(
+		mac=dir_make_zqcc / 'zqcc',
+		windows=dir_make_zqcc / 'Release' / 'zqcc.exe')
 
+	bin_zqgl = doset(
+		mac=dir_make_zquake / 'release-mac' / 'zquake-glsdl',
+		windows=dir_make_zquake / 'source' / 'Release-GL' / 'zquake-gl.exe')
 
-# FIXME DRY with the others - only diff is the check
-def platform_set_only_on(mac=None, windows=None):
-	if (mac and windows) or (not mac and not windows):
-		raise OnlyOnError()
+	bin_zqds = doset(
+		mac=dir_make_zquake / 'release-mac' / 'zqds',
+		windows=dir_make_zquake / 'source' / 'Release-server' / 'zqds.exe')
 
-	if system() == 'Darwin':
-		return mac
-	elif system() == 'Windows':
-		return windows
-	else:
-		raise NotImplementedError
+	dir_quake_tools = base / 'giants' / 'Quake-Tools'
+	dir_qutils = dir_quake_tools / 'qutils'
+	dir_qbsp = dir_qutils / 'qbsp'
+
+	dir_ldllib = base / 'ldl' / 'ldllib'
+
+	aq = base / 'audioquake'
+	file_aq_release = aq / 'release'
+	dir_dist = aq / 'dist'
+	dir_manuals = aq / 'manuals'
+	dir_manuals_converted = aq / 'manuals-converted'
+	dir_dist_rcon = dir_dist / 'rcon'
+	dir_maps_source = aq / 'maps'
+	dir_maps_quakewad = aq / 'maps-quakewad'
+	dir_maps_freewad = aq / 'maps-freewad'
+	dir_maps_prototypewad = aq / 'maps-prototypewad'
+
+	dir_aq_data = doset(
+		mac=dir_dist / 'AudioQuake.app' / 'Contents' / 'MacOS',
+		windows=dir_dist / 'AudioQuake')
+
+	dir_ldl = base / 'ldl'
+	dir_patches = dir_ldl / 'patches'

--- a/lib/ldllib/ldllib/build.py
+++ b/lib/ldllib/ldllib/build.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import platform
 import subprocess
 
+from buildlib import doset
+
 from .conf import prog
 from .utils import LDLError
 from .convert import WAD_FILES, WADs
@@ -131,7 +133,8 @@ def run(args, errorcheck=True, verbose=False, quiet=False, throw=False):
 	quiet      - whether to print anything to stdout (overrides 'verbose')
 	throw      - whether to raise a CalledProcessError if encountered"""
 	try:
-		res = subprocess.run(args, capture_output=True, check=errorcheck)
+		sh = doset(mac=False, windows=True)
+		res = subprocess.run(args, capture_output=True, check=errorcheck, shell=sh)
 		# We may not be doing strict error-checking (e.g. for vis) but still
 		# want to know when it didn't work
 		if not quiet and verbose:

--- a/lib/ldllib/ldllib/level_00_down_map2mapxml.py
+++ b/lib/ldllib/ldllib/level_00_down_map2mapxml.py
@@ -2,7 +2,7 @@
 """
 	level_00_down_map2mapxml.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MapXML file on stdin and prints a MAP file to stdout.

--- a/lib/ldllib/ldllib/level_00_up_map2mapxml.py
+++ b/lib/ldllib/ldllib/level_00_up_map2mapxml.py
@@ -2,7 +2,7 @@
 """
 	level_00_up_map2mapxml.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MAP file on stdin and prints a MapXML file to stdout.

--- a/lib/ldllib/ldllib/level_01_down_brushsizes.py
+++ b/lib/ldllib/ldllib/level_01_down_brushsizes.py
@@ -2,7 +2,7 @@
 """
 	level_01_down_brushsizes.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MapXML file on stdin with simplified brush

--- a/lib/ldllib/ldllib/level_01_up_brushsizes.py
+++ b/lib/ldllib/ldllib/level_01_up_brushsizes.py
@@ -2,7 +2,7 @@
 """
 	level_01_up_brushsizes.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MapXML file on stdin and simplifies the brush

--- a/lib/ldllib/ldllib/level_02_down_rooms.py
+++ b/lib/ldllib/ldllib/level_02_down_rooms.py
@@ -2,7 +2,7 @@
 """
 	level_02_down_rooms.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This stage takes a room definition and turns it into brushes.

--- a/lib/ldllib/ldllib/level_03_down_lighting.py
+++ b/lib/ldllib/ldllib/level_03_down_lighting.py
@@ -2,7 +2,7 @@
 """
 	level_03_down_lighting.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 """
 

--- a/lib/ldllib/ldllib/level_04_down_buildermacros.py
+++ b/lib/ldllib/ldllib/level_04_down_buildermacros.py
@@ -2,7 +2,7 @@
 """
 	level_04_down_buildermacros.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 """
 

--- a/lib/ldllib/ldllib/level_05_down_connections.py
+++ b/lib/ldllib/ldllib/level_05_down_connections.py
@@ -2,7 +2,7 @@
 """
 	level_05_down_connections.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 """
 

--- a/lib/ldllib/ldllib/utils.py
+++ b/lib/ldllib/ldllib/utils.py
@@ -1,7 +1,7 @@
 """
 	utils.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2019 Matthew Tylee Atkinson
+	Copyright 2005-2020 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This file contains the common code across all stack stages.


### PR DESCRIPTION
* DRY on the cross-platform and some built code.
* ConfigParser-based INI handling (currently for first-time checks).
* Update docs wrt Open Quartz.
* Don't use custom skins (fixes #11 - again? :-))
* UI labelling tweaks for clarity.
* Update code copyright ranges.
* Re-add GNU Free Documentation Licence (it is in there twice due to two docs that use it).
* Fix heading levels in docs.
* Fix map-building as part of build on Windows (don't flash up command prompt; fix cross-platform logic).
* Slightly less verbosity.
* Update change log.
* Update build instructions wrt Quake textures.