### PR TITLE
docs: Info for Mac users when App Translocation happens

### DIFF
--- a/audioquake/AudioQuake.py
+++ b/audioquake/AudioQuake.py
@@ -5,9 +5,10 @@ import traceback
 
 import wx
 
+from buildlib import doset_only
 from launcherlib.config import init as init_config
 from launcherlib.ui.launcher import LauncherWindow
-from launcherlib.ui.helpers import MsgBox
+from launcherlib.ui.helpers import MsgBox, Warn
 
 
 def error_hook(etype, value, trace):
@@ -26,6 +27,19 @@ if __name__ == '__main__':
 	app = wx.App()
 	sys.excepthook = error_hook
 	chdir(getattr(sys, '_MEIPASS', path.abspath(path.dirname(__file__))))
-	init_config()
-	LauncherWindow(None, "AudioQuake and LDL Launcher").Show()
-	app.MainLoop()
+	try:
+		init_config()
+		LauncherWindow(None, "AudioQuake and LDL Launcher").Show()
+		app.MainLoop()
+	except OSError:
+		doset_only(mac=lambda: Warn(None, (
+			'The code behind AudioQuake, Level Description Language and '
+			"supporting tools is not signed, so it can't be verified by "
+			'Apple.\n\n'
+
+			'If you still want to run them, move this application somewhere '
+			'else on your computer and re-open it.\n\n'
+
+			"If you've already done that, you may need to grant permission "
+			'for the application to access certain folders, in System '
+			'Preferences > Security & Privacy > Privacy tab.')))

--- a/audioquake/AudioQuake.spec
+++ b/audioquake/AudioQuake.spec
@@ -98,4 +98,4 @@ app = BUNDLE(  # noqa 821
 	name='AudioQuake.app',
 	icon=platform_icon,
 	info_plist=info_plist,
-	bundle_identifier=None)
+	bundle_identifier='uk.org.agrip.AudioQuake')


### PR DESCRIPTION
The reason why the downloaded app was not running is because App Translocation was placing it in a read-only filesystem at the start. Found out from https://github.com/portacle/portacle/issues/22 (thanks!) that one way to address this is for the user to move the app (after they have decided it is for them, and granted it permission to open via Gatekeeper). Included some documentation in the .app (that is only apparent _after_ the Gatekeeper part, of course) to explain they need to move the app to make it work.

I had started another branch in which the data were kept outside of the app (and other path-related improvements), but sticking with this for now.