### PR TITLE
fix(Mac): Ensure compilation still works

### DIFF
--- a/giants/zq-repo/zquake/Makefile
+++ b/giants/zq-repo/zquake/Makefile
@@ -165,7 +165,7 @@ RELEASE_BUILD_DIR		 =$(MAIN_DIR)/release-$(ARCH)
 # compiler flags
 PRJ_FLAGS				 = -DVWEP_TEST #-DHALFLIFEBSP
 MAUTH_FLAGS				 =-DMAUTH # the Master AUTHentication patch
-BASE_CFLAGS				 =-Wall -Wno-format-y2k -DAGRIP $(PRJ_FLAGS) $(ARCH_CFLAGS) $(MAUTH_FLAGS)
+BASE_CFLAGS				 =-Wall -Wno-implicit-function-declaration -Wno-format-y2k -DAGRIP $(PRJ_FLAGS) $(ARCH_CFLAGS) $(MAUTH_FLAGS)
 BASE_RELEASE_CFLAGS		 =-ffast-math -fomit-frame-pointer -fexpensive-optimizations
 ifneq ($(CC_BASEVERSION),4) # if we're not auto-vectorizing then we can unroll the loops (mdfour ahoy)
 	BASE_RELEASE_CFLAGS  += -funroll-loops

--- a/ldl/patches/makefile.patch
+++ b/ldl/patches/makefile.patch
@@ -4,7 +4,7 @@
 -
 -EXES = qbsp light vis bspinfo entmap visx
 -NTEXES = qbsp.exe light.exe vis.exe bspinfo.exe entmap.exe visx.exe
-+CFLAGS = -I ../common
++CFLAGS = -I ../common -Wno-implicit-function-declaration
 +EXES = qbsp light vis bspinfo
 +NTEXES = qbsp.exe light.exe vis.exe bspinfo.exe
  


### PR DESCRIPTION
Apparently since recent updates, errors have started stopping compilation (default compiler settings changed?) Whilst ideally these would be addressed in the source, nothing has changed in practice, so demoting the newly-ordained errors back to being warnings again.