### PR TITLE
feat: List key bindings

### DIFF
--- a/audioquake/AudioQuake.py
+++ b/audioquake/AudioQuake.py
@@ -6,7 +6,7 @@ from buildlib import doset_only
 import launcherlib.config as config
 import launcherlib.dirs as dirs
 from launcherlib.game_controller import GameController
-from launcherlib.utils import error_message_and_title, format_bindings
+from launcherlib.utils import error_message_and_title, format_bindings_as_text
 
 
 #
@@ -55,7 +55,7 @@ def play_mod(game_controller, args):
 
 
 def list_keys(game_controller, args):
-	config_bindings, autoexec_bindings = format_bindings()
+	config_bindings, autoexec_bindings = format_bindings_as_text()
 	print('config.cfg bindings')
 	print("\n".join(config_bindings))
 	print()

--- a/audioquake/AudioQuake.py
+++ b/audioquake/AudioQuake.py
@@ -6,7 +6,7 @@ from buildlib import doset_only
 import launcherlib.config as config
 import launcherlib.dirs as dirs
 from launcherlib.game_controller import GameController
-from launcherlib.utils import error_message_and_title
+from launcherlib.utils import error_message_and_title, format_bindings
 
 
 #
@@ -52,6 +52,15 @@ def list_mods(game_controller, args):
 def play_mod(game_controller, args):
 	# FIXME: check valid mod
 	_play_core(lambda: game_controller.launch_mod(args.dir))
+
+
+def list_keys(game_controller, args):
+	config_bindings, autoexec_bindings = format_bindings()
+	print('config.cfg bindings')
+	print("\n".join(config_bindings))
+	print()
+	print('autoexec.cfg bindings')
+	print("\n".join(autoexec_bindings))
 
 
 #
@@ -110,6 +119,9 @@ if __name__ == '__main__':
 	mod_cmd = subparsers.add_parser('mod', help='Boot into a particular mod')
 	mod_cmd.add_argument('dir', help="The mod's directory name")
 	mod_cmd.set_defaults(func=play_mod)
+
+	ls_keys_cmd = subparsers.add_parser('list-keys', help='List key bindings')
+	ls_keys_cmd.set_defaults(func=list_keys)
 
 	parser.set_defaults(func=gui_main)
 	args = parser.parse_args()

--- a/audioquake/launcherlib/ui/tabs/help.py
+++ b/audioquake/launcherlib/ui/tabs/help.py
@@ -11,9 +11,9 @@ class HelpTab(wx.Panel):
 		sizer = wx.BoxSizer(wx.VERTICAL)
 
 		add_opener_buttons(self, sizer, {
+			'README': dirs.manuals / 'README.html',
 			'User manual': dirs.manuals / 'user-manual.html',
 			'Sound legend': dirs.manuals / 'sound-legend.html',
-			'README': dirs.manuals / 'README.html',
 			'LICENCE': dirs.manuals / 'LICENCE.html'
 		})
 

--- a/audioquake/launcherlib/ui/tabs/mod.py
+++ b/audioquake/launcherlib/ui/tabs/mod.py
@@ -24,6 +24,8 @@ class ModTab(wx.Panel):
 		install_qmod_button.Bind(wx.EVT_BUTTON, self.install_qmod_handler)
 		add_widget(sizer, install_qmod_button)
 
+		add_widget(sizer, wx.StaticLine(self, -1))
+
 		add_opener_button(
 			self, sizer, 'Development manual',
 			dirs.manuals / 'development-manual.html')

--- a/audioquake/launcherlib/ui/tabs/play.py
+++ b/audioquake/launcherlib/ui/tabs/play.py
@@ -7,7 +7,7 @@ except ImportError:
 import wx
 import wx.html2
 
-from buildlib import doset
+from buildlib import doset, doset_only
 from launcherlib import dirs
 from launcherlib.utils import have_registered_data, format_bindings_as_html
 from launcherlib.ui.helpers import add_widget, launch_core, \
@@ -60,7 +60,7 @@ def run_win_console(prog):
 
 
 #
-# Helpers
+# General helpers
 #
 
 def add_launch_button(parent, sizer, title, action):
@@ -79,6 +79,15 @@ def add_cli_tool_button(parent, sizer, title, action):
 	button = wx.Button(parent, -1, title)
 	button.Bind(wx.EVT_BUTTON, action)
 	add_widget(sizer, button)
+
+
+def windows_accessibility_fix(browser):
+	robot = wx.UIActionSimulator()
+	browser.SetFocus()
+	position = browser.GetPosition()
+	position = browser.ClientToScreen(position)
+	robot.MouseMove(position)
+	robot.MouseClick()
 
 
 #
@@ -105,6 +114,8 @@ class KeyBindingsView(wx.Dialog):
 		add_widget(sizer, close)
 
 		self.SetSizer(sizer)
+
+		doset_only(windows=lambda: windows_accessibility_fix(browser))
 
 
 class PlayTab(wx.Panel):

--- a/audioquake/launcherlib/ui/tabs/play.py
+++ b/audioquake/launcherlib/ui/tabs/play.py
@@ -5,10 +5,11 @@ except ImportError:
 	pass
 
 import wx
+import wx.html2
 
 from buildlib import doset
 from launcherlib import dirs
-from launcherlib.utils import have_registered_data
+from launcherlib.utils import have_registered_data, format_bindings_as_html
 from launcherlib.ui.helpers import add_widget, launch_core, \
 	Error, HOW_TO_INSTALL
 
@@ -84,10 +85,34 @@ def add_cli_tool_button(parent, sizer, title, action):
 # The main event
 #
 
+class KeyBindingsView(wx.Dialog):
+	def __init__(self, parent):
+		screen_width, screen_height = wx.GetDisplaySize()
+
+		wx.Dialog.__init__(
+			self, parent, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
+			size=(screen_width * 0.5, screen_height * 0.7),
+			title='Key bindings')
+		sizer = wx.BoxSizer(wx.VERTICAL)
+
+		browser = wx.html2.WebView.New(self)
+		display = format_bindings_as_html()
+		browser.SetPage(display, "")
+		sizer.Add(browser, 1, wx.EXPAND, 10)
+
+		close = wx.Button(self, -1, 'Close')
+		close.Bind(wx.EVT_BUTTON, lambda event: self.Destroy())
+		add_widget(sizer, close)
+
+		self.SetSizer(sizer)
+
+
 class PlayTab(wx.Panel):
 	def __init__(self, parent, game_controller):
 		wx.Panel.__init__(self, parent)
 		sizer = wx.BoxSizer(wx.VERTICAL)
+
+		# Playing the game
 
 		game_modes = {
 			"Play Quake": game_controller.launch_quake,
@@ -100,6 +125,22 @@ class PlayTab(wx.Panel):
 
 		for title, action in game_modes.items():
 			add_launch_button(self, sizer, title, action)
+
+		# Listing key bindings
+
+		add_widget(sizer, wx.StaticLine(self, -1))
+
+		bindings = wx.Button(self, -1, 'List key bindings')
+
+		def bindings_window(event):
+			KeyBindingsView(self).Show()
+
+		bindings.Bind(wx.EVT_BUTTON, bindings_window)
+		add_widget(sizer, bindings)
+
+		# Server stuff
+
+		add_widget(sizer, wx.StaticLine(self, -1))
 
 		server_stuff = {
 			"Dedicated server": doset(

--- a/audioquake/launcherlib/utils.py
+++ b/audioquake/launcherlib/utils.py
@@ -62,7 +62,7 @@ def error_message_and_title(etype, value, traceback):
 def get_bindings():
 	config_keys = []
 
-	standard_binding = re.compile(r'^bind (.+) "(.+)"$')
+	standard_binding = re.compile(r'^bind (.+) "\+?(.+)"$')
 	ignores = ['echo', 'screenshot', 'impulse', '`', 'MOUSE']
 
 	with open(dirs.data / 'id1' / 'config.cfg', 'r') as cfg:
@@ -95,7 +95,7 @@ def get_bindings():
 	return config_keys, autoexec_keys
 
 
-def format_bindings():
+def format_bindings_as_text():
 	config_keys, autoexec_keys = get_bindings()
 
 	config_list = [f"{key['current']} {key['action']}" for key in config_keys]
@@ -104,3 +104,33 @@ def format_bindings():
 		for key in autoexec_keys]
 
 	return config_list, autoexec_list
+
+
+def format_bindings_as_html():
+	config_keys, autoexec_keys = get_bindings()
+
+	html = '<!DOCTYPE html><head><style>\n' \
+		+ 'table { border-collapse: collapse; }\n' \
+		+ 'th, td { padding: 0.5em; border: 1px solid gray; }</style>\n' \
+		+ '</head><body>\n' \
+		+ '<h1>Key bindings</h1>' \
+		+ '<p>This page shows your current key bindings. To change them, ' \
+		+ 'check out the Customise tab, and the comments in the config files ' \
+		+ 'as well as the user manual.\n' \
+		+ '<h2>Basic movement and action keys</h2>\n'
+
+	html += '<table><tr><th>Key</th><th>Action</th></tr>\n'
+	for key in config_keys:
+		html += f"<tr><td>{key['current']}</td><td>{key['action']}</td></tr>\n"
+	html += '</table>\n'
+
+	html += '<h2>Navigation helpers, devices, bots, messages and more</h2>\n'
+	html += '<table><tr><th>Current</th><th>Action</th><th>Default</th></tr>\n'
+	for key in autoexec_keys:
+		html += (
+			f"<tr><td>{key['current']}</td><td>{key['help']}</td>"
+			f"<td>{key['default']}</td></tr>\n")
+	html += '</table>\n'
+
+	html += '</body></html>'
+	return html

--- a/audioquake/launcherlib/utils.py
+++ b/audioquake/launcherlib/utils.py
@@ -1,5 +1,6 @@
 """AudioQuake & LDL Launcher - Utilities"""
 import enum
+import re
 from subprocess import check_call
 from traceback import format_exception_only, format_tb
 
@@ -56,3 +57,50 @@ def error_message_and_title(etype, value, traceback):
 		title = 'Unanticipated error (launcher bug)'
 
 	return message, title
+
+
+def get_bindings():
+	config_keys = []
+
+	standard_binding = re.compile(r'^bind (.+) "(.+)"$')
+	ignores = ['echo', 'screenshot', 'impulse', '`', 'MOUSE']
+
+	with open(dirs.data / 'id1' / 'config.cfg', 'r') as cfg:
+		key = {}
+		for line in cfg.readlines():
+			ignore = any(map(lambda term: term in line, ignores))
+			if not ignore:
+				if match := standard_binding.match(line):
+					key['current'] = match.group(1)
+					key['action'] = match.group(2)
+					config_keys.append(key)
+					key = {}
+
+	autoexec_keys = []
+
+	alias_binding = re.compile(r'^bind "(.+)" "aga_\w+"$')
+	alias_default = re.compile(r'^// default key (?:to|for) (.+) is "(.+)"$')
+
+	with open(dirs.data / 'id1' / 'autoexec.cfg', 'r') as cfg:
+		key = {}
+		for line in cfg.readlines():
+			if match := alias_binding.match(line):
+				key['current'] = match.group(1)
+			elif match := alias_default.match(line):
+				key['help'] = match.group(1)
+				key['default'] = match.group(2)
+				autoexec_keys.append(key)
+				key = {}
+
+	return config_keys, autoexec_keys
+
+
+def format_bindings():
+	config_keys, autoexec_keys = get_bindings()
+
+	config_list = [f"{key['current']} {key['action']}" for key in config_keys]
+	autoexec_list = [
+		f"{key['current']} {key['help']} (default: {key['default']})"
+		for key in autoexec_keys]
+
+	return config_list, autoexec_list

--- a/audioquake/launcherlib/utils.py
+++ b/audioquake/launcherlib/utils.py
@@ -60,7 +60,9 @@ def error_message_and_title(etype, value, traceback):
 
 
 def get_bindings():
-	config_keys = []
+	config_keys_directions = {
+		'forward': None, 'back': None, 'left': None, 'right': None}
+	config_keys_other = []
 
 	standard_binding = re.compile(r'^bind (.+) "\+?(.+)"$')
 	ignores = ['echo', 'screenshot', 'impulse', '`', 'MOUSE']
@@ -72,8 +74,12 @@ def get_bindings():
 			if not ignore:
 				if match := standard_binding.match(line):
 					key['current'] = match.group(1)
-					key['action'] = match.group(2)
-					config_keys.append(key)
+					action = match.group(2)
+					key['action'] = action
+					if action in config_keys_directions:
+						config_keys_directions[action] = key
+					else:
+						config_keys_other.append(key)
 					key = {}
 
 	autoexec_keys = []
@@ -91,6 +97,8 @@ def get_bindings():
 				key['default'] = match.group(2)
 				autoexec_keys.append(key)
 				key = {}
+
+	config_keys = list(config_keys_directions.values()) + config_keys_other
 
 	return config_keys, autoexec_keys
 


### PR DESCRIPTION
Provides a command-line option and GUI dialog that gets the user's current keybindings from their config files.

Only looks in "id1" (which is OK). Does rely on the formats of the config files. May want to add specific error handling in future maybe.