### PR TITLE
fix: QMOD error handling and tolerance

### DIFF
--- a/audioquake/launcherlib/game_controller/__init__.py
+++ b/audioquake/launcherlib/game_controller/__init__.py
@@ -88,7 +88,6 @@ class GameController():
 			self.opts_custom_map_base + ('+map ' + str(name),), game=game)
 
 	def launch_mod(self, name):
-		print('Launching mod:', name)
 		return self._launch_core(('-game', name))
 
 	def quit(self):

--- a/audioquake/launcherlib/ui/tabs/map.py
+++ b/audioquake/launcherlib/ui/tabs/map.py
@@ -163,7 +163,7 @@ class MapTab(wx.Panel):
 			try:
 				self.build_and_copy(xmlfile, wad, destinations)
 			except LDLError:
-				Error(self, str(exc_info()[1]))
+				Error(self, str(exc_info()[1]))  # TODO: Why not str(err)?
 				return
 
 		if play_wad:

--- a/audioquake/launcherlib/ui/tabs/mod.py
+++ b/audioquake/launcherlib/ui/tabs/mod.py
@@ -40,8 +40,7 @@ class ModTab(wx.Panel):
 			try:
 				qmod = QMODFile(incoming)
 			except BadQMODFileError as err:
-				Error(
-					self, 'There is a problem with the QMOD file: ' + str(err))
+				Error(self, f'There is a problem with the QMOD file: {err}.')
 				return
 
 			title = qmod.name + ' ' + qmod.version

--- a/audioquake/launcherlib/ui/tabs/mod.py
+++ b/audioquake/launcherlib/ui/tabs/mod.py
@@ -4,9 +4,9 @@ import wx
 from launcherlib import dirs
 from launcherlib.ui.helpers import \
 	add_widget, add_opener_button, pick_file, launch_core, \
-	Info, YesNoWithTitle
+	Info, YesNoWithTitle, Error
 
-from qmodlib import QMODFile, InstalledQMOD
+from qmodlib import QMODFile, InstalledQMOD, BadQMODFileError
 
 
 class ModTab(wx.Panel):
@@ -37,7 +37,13 @@ class ModTab(wx.Panel):
 		incoming = pick_file(
 			self, "Select a QMOD file", "QMOD files (*.qmod)|*.qmod")
 		if incoming:
-			qmod = QMODFile(incoming)
+			try:
+				qmod = QMODFile(incoming)
+			except BadQMODFileError as err:
+				Error(
+					self, 'There is a problem with the QMOD file: ' + str(err))
+				return
+
 			title = qmod.name + ' ' + qmod.version
 			desc = qmod.shortdesc + '\n\n' + qmod.longdesc
 

--- a/audioquake/qmodlib.py
+++ b/audioquake/qmodlib.py
@@ -5,15 +5,15 @@ import shutil
 from zipfile import ZipFile
 
 
-class BadQMODFileException(Exception):
+class BadQMODFileError(Exception):
 	pass
 
 
-class NoQMODDirectoryException(Exception):
+class NoQMODDirectoryError(Exception):
 	pass
 
 
-class BadQMODDirectoryException(Exception):
+class BadQMODDirectoryError(Exception):
 	pass
 
 
@@ -21,14 +21,14 @@ class QMODFile():
 	def __init__(self, path):
 		zipfile = ZipFile(path, mode='r')
 		if zipfile.testzip() is not None:
-			raise BadQMODFileException("'" + path + "' failed zip test")
+			raise BadQMODFileError("'" + path + "' failed zip test")
 		files = zipfile.namelist()
 		if 'qmod.ini' not in files:
-			raise BadQMODFileException("Missing 'qmod.ini'")
+			raise BadQMODFileError("Missing 'qmod.ini'")
 		files.remove('qmod.ini')
 		dirs = set([Path(x).parts[0] for x in files])
 		if len(dirs) > 1:
-			raise BadQMODFileException('Improper directory structure')
+			raise BadQMODFileError('Improper directory structure')
 
 		ini_string = zipfile.read('qmod.ini').decode('utf-8')
 		config = ConfigParser()
@@ -56,12 +56,12 @@ class InstalledQMOD():
 		path = Path(name)
 
 		if not path.is_dir():
-			raise NoQMODDirectoryException()
+			raise NoQMODDirectoryError()
 
 		ini_path = path / 'qmod.ini'
 
 		if not ini_path.is_file():
-			raise BadQMODDirectoryException()
+			raise BadQMODDirectoryError()
 
 		config = ConfigParser()
 		config.read_file(open(ini_path))


### PR DESCRIPTION
* Add quite a bit of general QMOD error handling. Errors in QMODs are no longer reported as Launcher bugs.
* Handle when all files in a QMOD are wrapped within a top-level directory (this is not as specced, but has happened in the wild—possibly to do with the default behaviour of OSes/specific compression tools when multiple files are selected?)
* Ignore any qmod.ini files that aren't in the toppest level of the mod.

Fixes #70