### PR TITLE
docs: Sort out special chars in docs on Windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -23,7 +23,7 @@ There are three main components that are brought together by the build process.
 
 1. The engine, QuakeC compiler, gamecode and Quake map compilation tools, written predominantly in C (with some QuakeC), which need to be compiled. These can be found in the "giants" directory.
 2. AudioQuake is based on these and adds all of the custom game assets, launcher, support for mods, and documentation. The "audioquake" directory contains all of that stuff. The AudioQuake launcher and build system is written in Python.
-3. The Level Description Language tools and documentation can be found in the "ldl" directory—though the relevant files from there are automagically brought in to AudioQuake builds, so anyone can access them via the GUI launcher. You only need to venture into LDL's directory if you want to use it stand-alone on the command-line, and that's only currently supported on the Mac. LDL is also written in Python.
+3. The Level Description Language tools and documentation can be found in the "ldl" directory&mdash;though the relevant files from there are automagically brought in to AudioQuake builds, so anyone can access them via the GUI launcher. You only need to venture into LDL's directory if you want to use it stand-alone on the command-line, and that's only currently supported on the Mac. LDL is also written in Python.
 
 When you make a build of AudioQuake and Level Description Language, the Python code is "frozen" into a form that runs without the need for Python to be installed. A build has to be made on the platform (Mac or Windows) on which it's intended to be run.
 
@@ -42,7 +42,7 @@ These instructions were tested on macOS Catalina (10.15).
 * We also strongly recommend that you install the packages `git` and `bash-completion` (which allows you to quickly tab-complete many commands) to make working on the command line easy. Do this by running `brew install bash-completion` and `brew install git`. If you prefer a graphical UI for Git (and GitHub), you can install [GitHub Desktop](http://desktop.github.com).
 * Make sure you've added Homebrew's install location, `/usr/local/`, to your path, so that later on when you install Python via Homebrew, it will run that version rather than the macOS system version.
 
-After the above steps, you should end up with something like the following in your `~/.bashrc` file—you'll probably need to restart your shell for this to take effect.
+After the above steps, you should end up with something like the following in your `~/.bashrc` file&mdash;you'll probably need to restart your shell for this to take effect.
 
 ```bash
 export PATH=/usr/local/sbin:/usr/local/bin:$PATH
@@ -118,7 +118,7 @@ On both Mac and Windows, the build scripts can compile the engine and related co
 
 On Windows, a batch file that's part of the MS Build tools, or Visual Studio, is used to ensure that the compiler can be found. The `build-all.py` script assumes that you're using Command Prompt (not PowerShell) as your command-line interface.
 
-Further, on Windows, to ensure that the environment variables are usable, `build-all.py` actually creates a batch file that calls Microsoft's one to set up the development tools and then calls `build-giants.py` and `build-audioquake.py`—this is all handled for you, though.
+Further, on Windows, to ensure that the environment variables are usable, `build-all.py` actually creates a batch file that calls Microsoft's one to set up the development tools and then calls `build-giants.py` and `build-audioquake.py`&mdash;this is all handled for you, though.
 
 ### What do the build scripts do?
 

--- a/audioquake/CHANGELOG.md
+++ b/audioquake/CHANGELOG.md
@@ -20,7 +20,7 @@ that you could more easily make levels for it.
     or a new set of high-contrast textures.
 -   More flexible styling of LDL maps (supporting the above sets of
     textures, as well as additional styles you can apply to parts of
-    maps, e.g. to make some areas appear outside).
+    maps, e.g. to make some areas appear outside).
 -   The launcher can load in the registered Quake data if you bought the
     game.
 -   Big documentation updates.

--- a/audioquake/manuals/development-manual-part01.md
+++ b/audioquake/manuals/development-manual-part01.md
@@ -10,7 +10,7 @@ Permission is granted to copy, distribute and/or modify this document under the 
 
 As with the user manual, please note this has been edited to keep it technically up-to-date, but is largely as written in the mid-2000s. Whilst you still *could* use *AudioQuake* as a development platform, it'd be more fun to work on creating the next accessible games development platform :-).
 
-Alas the *Stats and Servers* system is no longer in operation due to time and support constraints, and we'd rather work to the future regarding the accessible level-editing tools mentioned here—but you can still use them to make levels non-visually, as discussed in the *Level Description Language (LDL)* tutorial.
+Alas the *Stats and Servers* system is no longer in operation due to time and support constraints, and we'd rather work to the future regarding the accessible level-editing tools mentioned here&mdash;but you can still use them to make levels non-visually, as discussed in the *Level Description Language (LDL)* tutorial.
 
 ## Background information
 

--- a/audioquake/manuals/development-manual-part01.md
+++ b/audioquake/manuals/development-manual-part01.md
@@ -42,7 +42,7 @@ Our goal was to provide blind and vision-impaired people with the tools to make 
 
 ### Licencing
 
-AGRIP is an Open Source project, based on the groundbreaking work of id Software, the *ZQuake* and *QuakeForge* projects, and many others. Anyone is welcome to use our tools and code in the creation of their own games, provided that they keep their creations open (i.e. release the source and derived data files, under the GNU General Public Licence).
+AGRIP is an Open Source project, based on the groundbreaking work of id Software, the *ZQuake* and *QuakeForge* projects, and many others. Anyone is welcome to use our tools and code in the creation of their own games, provided that they keep their creations open (i.e. release the source and derived data files, under the GNU General Public Licence).
 
 If you are interested in using our software as the basis for your own, you must read the licence fully and ensure that you are aware of its ramifications.
 

--- a/audioquake/manuals/development-manual-part03.md
+++ b/audioquake/manuals/development-manual-part03.md
@@ -76,7 +76,7 @@ The gamecode used in *AudioQuake* has two main goals:
 
 Many functions created in the development of *AudioQuake* are written to be as generic as possible. They form what could be thought of as an "accessibility library" on top of the standard QuakeC.
 
-**Anecdote:** This modular design approach was tested… all bot navigation code was modified to use the AGRIP accessibility aid functions. This meant that the bots' perception of the world was essentially that of a blind player. The bots performed well and began to navigate in a similar style to that of most blind gamers.
+**Anecdote:** This modular design approach was tested&hellip; all bot navigation code was modified to use the AGRIP accessibility aid functions. This meant that the bots' perception of the world was essentially that of a blind player. The bots performed well and began to navigate in a similar style to that of most blind gamers.
 
 ### Layout and design
 

--- a/audioquake/manuals/development-manual-part03.md
+++ b/audioquake/manuals/development-manual-part03.md
@@ -14,7 +14,7 @@ The whole gamecode for *Quake*, with AGRIP extensions, and any modifications you
 
 QuakeC is similar to C in nature. This is not a tutorial on the language itself; it is assumed the reader is used to programming in general. Much information can be found through the resources listed in [appendix section](#ref-qc) on the matter.
 
-### Building Code—The Basics
+### Building Code&mdash;The Basics
 
 QuakeC (`.qc`) files must be compiled into a `.dat` to be run by the game. The gamecode for the entire game is composed of many QuakeC files. Some of the files are only applicable to the single-player game and some are multiplayer-specific, so actually two `.dat` files are usually built (one for each type of gameplay).
 
@@ -40,7 +40,7 @@ The *ZQuake* project hosts gamecode for a number of popular game modes and mods.
 
 * qw
 
-  Where it all started—a maintained version of the *QuakeWorld* (DM, Classic TeamDM) gamecode.
+  Where it all started&mdash;a maintained version of the *QuakeWorld* (DM, Classic TeamDM) gamecode.
 
 * qwsp
 
@@ -58,7 +58,7 @@ The *ZQuake* project hosts gamecode for a number of popular game modes and mods.
 
 As has been pointed out, much of the code hare is linked and when you develop a mod, we recommend you start a new top-level directory in here and reuse as much of the existing code as you can. Start with one of the AGRIP `progs.src` files and add any extra `.qc` files you might need in your own directory.
 
-**Note:** If you need to override any functions in the main code, don't replace an entire file with your own version—there is a way for you to override individual functions elsewhere in the code, which will be explained later.
+**Note:** If you need to override any functions in the main code, don't replace an entire file with your own version&mdash;there is a way for you to override individual functions elsewhere in the code, which will be explained later.
 
 Constructing your mod in this way has the advantages of much easier upgrades between AGRIP versions (as if you follow the guidelines here you'll be hooking into our code mostly and won't have to worry about changes in the stock *ZQuake* code). It also keeps your mod's codebaese small, simple and therefore easy to maintain and (hopefully\!) more reliable.
 

--- a/audioquake/manuals/development-manual-part03.md
+++ b/audioquake/manuals/development-manual-part03.md
@@ -6,7 +6,7 @@
 
 QuakeC is a high-level gamecode language that is compiled into bytecode/assembly instructions for the QuakeC Virtual Machine (in much the same way that Java and Perl work). The virtual machine is what executes your compiled-down code (the `.dat` files). The reasons why a virtual machine is used are portability (QuakeC works on all platforms that *Quake* does) and security (your mod cannot access anything outside of the QuakeC VM, other than the "builtin" functions that the *Quake* engine provides).
 
-The engine provides builtin functions for doing performance-critical calculations (such as working out if a particular 3D vector corresponding to the aim of a weapon would hit a player) and interfacing with the outside world via the presentation of content to the user, such as sounds (e.g. when a weapon fires, a sound is made).
+The engine provides builtin functions for doing performance-critical calculations (such as working out if a particular 3D vector corresponding to the aim of a weapon would hit a player) and interfacing with the outside world via the presentation of content to the user, such as sounds (e.g. when a weapon fires, a sound is made).
 
 The whole gamecode for *Quake*, with AGRIP extensions, and any modifications you make must be compiled together into one `.dat` file. All of the code you need is in the Subversion repository. Unfortunately this has the side effect that only one modification can running any time; the Unreal engine (which powers a competing series of games) provides some ways to combat this and run multiple modifications at once. Alas it is not Open Source so hasn't been made accessible yet. In practise this limitation of the *Quake* engine should not make too much difference, as the user can have multiple mods installed at any time (the game launcher and QMOD system take care of this).
 
@@ -80,7 +80,7 @@ Many functions created in the development of *AudioQuake* are written to be as g
 
 ### Layout and design
 
-Our recommended method of setting up your mod, in terms of directory structure and code re-use, can be found above. This section explains how the AGRIP code is laid out internally (i.e. inside the `agrip/` directory).
+Our recommended method of setting up your mod, in terms of directory structure and code re-use, can be found above. This section explains how the AGRIP code is laid out internally (i.e. inside the `agrip/` directory).
 
 **Tip:** The source code is heavily commented; take advantage of this to learn how to make best use of the library code that has been written for your mods.
 

--- a/audioquake/manuals/development-manual-part04.md
+++ b/audioquake/manuals/development-manual-part04.md
@@ -62,7 +62,7 @@ It's easy\! You need to package up all the files required by your mod, in a part
 
 5. Zip up the parent directory so that you have created a ZIP file with two items in it&mdash;the MOD's installation directory and the `qmod.ini` file.
 
-   Finally, rename the ZIP file to the name of the parent directory (i.e. the MOD's name) with a `.qmod` extension to replace the `.zip` one it pops out of your ZIP creator with.
+   Finally, rename the ZIP file to the name of the parent directory (i.e. the MOD's name) with a `.qmod` extension to replace the `.zip` one it pops out of your ZIP creator with.
 
 ## How? (for users)
 

--- a/audioquake/manuals/development-manual-part04.md
+++ b/audioquake/manuals/development-manual-part04.md
@@ -21,7 +21,7 @@ We felt that those of you making total conversions would want to make your own s
 
 ## How? (for developers)
 
-It's easy\! You need to package up all the files required by your mod, in a particular way, then create an INI file to describe your mod to the installer. Here is how…
+It's easy\! You need to package up all the files required by your mod, in a particular way, then create an INI file to describe your mod to the installer. Here is how&hellip;
 
 1. Ensure that you have packaged up all the files your mod needs (sound, progs, models, maps, graphics) into the correct directory structure below your *AudioQuake* parent directory.
 

--- a/audioquake/manuals/development-manual-part04.md
+++ b/audioquake/manuals/development-manual-part04.md
@@ -5,13 +5,13 @@
 
 ### What?
 
-This is all about a format for packaging your modifications that will make them easy to install by end-users. The QMOD system is basically a rip-off of a similar idea used by the game *Unreal*—users are given a single file that contains the modification and some metadata; when they open this file, the game interprets the metadata and presents a set-up routine specific to that mod but using the game's standard user interface.
+This is all about a format for packaging your modifications that will make them easy to install by end-users. The QMOD system is basically a rip-off of a similar idea used by the game *Unreal*&mdash;users are given a single file that contains the modification and some metadata; when they open this file, the game interprets the metadata and presents a set-up routine specific to that mod but using the game's standard user interface.
 
 ### Why?
 
 As far as the user is concerned, installing mods for the game will be easy, with a guaranteed user interface and level of accessibility. They also get to choose which mod to play, from a list of installed ones, via the launcher. Finally, they can also uninstall mods easily, again via the launcher.
 
-For the developer, you get the benefit of giving your users the above benefits with very little work—simply package your mod up in the way described here, adding the required metadata\! In addition, you can ask the launcher to keep your mod's config files up-to-date with any changes put into the user's standard game config files (at no development cost to yourself).
+For the developer, you get the benefit of giving your users the above benefits with very little work&mdash;simply package your mod up in the way described here, adding the required metadata\! In addition, you can ask the launcher to keep your mod's config files up-to-date with any changes put into the user's standard game config files (at no development cost to yourself).
 
 #### Why not?
 
@@ -60,7 +60,7 @@ It's easy\! You need to package up all the files required by your mod, in a part
    03=See the jediquake folder for documentation.
    ```
 
-5. Zip up the parent directory so that you have created a ZIP file with two items in it—the MOD's installation directory and the `qmod.ini` file.
+5. Zip up the parent directory so that you have created a ZIP file with two items in it&mdash;the MOD's installation directory and the `qmod.ini` file.
 
    Finally, rename the ZIP file to the name of the parent directory (i.e. the MOD's name) with a `.qmod` extension to replace the `.zip` one it pops out of your ZIP creator with.
 

--- a/audioquake/manuals/development-manual-part08.md
+++ b/audioquake/manuals/development-manual-part08.md
@@ -12,7 +12,7 @@ This section contains links to web sites I found useful whilst developing the AG
 * [QuakeC Reference Manual by David "DarkGrue" Hesprich (darkgrue@iname.com)](http://tylee.f2s.com/agrip/ref/QuakeC%20Reference%20Manual.doc)
     Another very good basics-to-advanced tutorial on QuakeC.
 * [The *Quake* Wiki](http://wiki.quakesrc.org/)
-    This site contains a comprehensive list of QuakeC functions, their availability in different engines and standard engine extensions—and includes detailed information on most of them.
+    This site contains a comprehensive list of QuakeC functions, their availability in different engines and standard engine extensions&mdash;and includes detailed information on most of them.
 * [Inside3D QuakeC Tutorials](http://www.inside3d.com/qctut/)
     Some great tutorials can be found here, but beware of the pop-ups :-S.
 * [AI Cafe Tutorials](http://www.planetquake.com/minion/tutorial%5Cmain.htm)
@@ -20,8 +20,8 @@ This section contains links to web sites I found useful whilst developing the AG
 
 ## *Quake* Engines and Standards
 
-* [QuakeSrc.org—The *Quake* Standards Group](http://www.quakesrc.org/)
-    *The* site for engine developers and modders — includes news and a list of extensions, with a community-based protocol for having new ones added.
+* [QuakeSrc.org&mdash;The *Quake* Standards Group](http://www.quakesrc.org/)
+    *The* site for engine developers and modders &mdash; includes news and a list of extensions, with a community-based protocol for having new ones added.
 * [ZQuake Development Board](http://www.besmella-*quake*.com/scripts/zquake/index.cgi)
     A place to report bugs/fixes, ask questions and get help with adding new features to this amazing *QuakeWorld* engine.
 
@@ -46,6 +46,6 @@ This section contains links to web sites I found useful whilst developing the AG
 
 * [DocBook.org](http://www.docbook.org/)
     Provides some general information on the standard.
-* [DocBook—The Definitive Guide](http://www.docbook.org/tdg/en/html/docbook.html)
+* [DocBook&mdash;The Definitive Guide](http://www.docbook.org/tdg/en/html/docbook.html)
     The complete reference manual.
 

--- a/audioquake/manuals/development-manual-part09.md
+++ b/audioquake/manuals/development-manual-part09.md
@@ -1,7 +1,7 @@
 <a name="qmod-ini"></a>
 ## `qmod.ini` file settings
 
-The following sections detail the various options available to mod authors in `qmod.ini` files. The are split into the two (current) sections of the INI file—"general" and "longdesc".
+The following sections detail the various options available to mod authors in `qmod.ini` files. The are split into the two (current) sections of the INI file&mdash;"general" and "longdesc".
 
 ### General
 

--- a/audioquake/manuals/development-manual-part09.md
+++ b/audioquake/manuals/development-manual-part09.md
@@ -34,7 +34,7 @@ watch_autoexec=yes
 
 This section is optional and, if included, is used to give the user more information about the mod when they select it in the game launcher's menu.
 
-Create it by assigning each "chunk" of your mod's description to a key. Each chunk must be less than 80 characters long. Use keys which, when sorted, will result in the correct ordering of chunks (i.e. just number each chunk).
+Create it by assigning each "chunk" of your mod's description to a key. Each chunk must be less than 80 characters long. Use keys which, when sorted, will result in the correct ordering of chunks (i.e. just number each chunk).
 
 The obligatory example:
 

--- a/audioquake/manuals/user-manual-part01.md
+++ b/audioquake/manuals/user-manual-part01.md
@@ -26,7 +26,7 @@ Over the years since, it's been truly awesome to witness the strides and leaps i
 
 *AudioQuake* is essentially a series of modifications to the game *Quake* by id Software that enable blind and vision-impaired people to play it. Actually, it is (or will be) quite a lot more than just that. This chapter explains the main things you need to know about *AudioQuake* to understand what it does and why it's here.
 
-So, *AudioQuake* is…
+So, *AudioQuake* is&hellip;
 
 ### More than just an "accessible game"
 
@@ -68,7 +68,7 @@ The process of customisation is described [in the "Customising *AudioQuake*" sec
 
 Everything we have created for the project (code, sounds, tools) is available for you to use, modify and redistribute. The licence we have used for the project, the GNU General Public Licence, permits anyone to do these things as long as they keep the source code to their work available for others, just as we have for you.
 
-Our reasons for making *AudioQuake* Free are that it should make it easier for people to get hold of and play the game. The most important reason, however, is described in the following section…
+Our reasons for making *AudioQuake* Free are that it should make it easier for people to get hold of and play the game. The most important reason, however, is described in the following section&hellip;
 
 ### Only the beginning
 

--- a/audioquake/manuals/user-manual-part01.md
+++ b/audioquake/manuals/user-manual-part01.md
@@ -6,7 +6,7 @@ Permission is granted to copy, distribute and/or modify this document under the 
 
 This part of the manual aims to introduce *AudioQuake* and gives you details on how to get it set up on your computer.
 
-If you're interested in historical details, this is the section for you—but if you just want to get into playing the game, by all means visit [the "Playing *AudioQuake*" section](#playing-audioquake) instead.
+If you're interested in historical details, this is the section for you&mdash;but if you just want to get into playing the game, by all means visit [the "Playing *AudioQuake*" section](#playing-audioquake) instead.
 
 ## Digital archaeology note from 2020
 
@@ -22,7 +22,7 @@ Over the years since, it's been truly awesome to witness the strides and leaps i
 
 ## What is *AudioQuake*?
 
-**This section of the document is kept relatively unchanged from the mid-2000s. Whilst *Quake* is now ancient (but still a milestone in gaming) and accessible games and mainstream game accessibility have taken off massively, we wanted to preserve the spirit of this part. It also mentions things that, whilst we'd've loved to work on, we never got time—but again they're preserved here for posterity.**
+**This section of the document is kept relatively unchanged from the mid-2000s. Whilst *Quake* is now ancient (but still a milestone in gaming) and accessible games and mainstream game accessibility have taken off massively, we wanted to preserve the spirit of this part. It also mentions things that, whilst we'd've loved to work on, we never got time&mdash;but again they're preserved here for posterity.**
 
 *AudioQuake* is essentially a series of modifications to the game *Quake* by id Software that enable blind and vision-impaired people to play it. Actually, it is (or will be) quite a lot more than just that. This chapter explains the main things you need to know about *AudioQuake* to understand what it does and why it's here.
 
@@ -34,7 +34,7 @@ So, *AudioQuake* is…
 
 * Support for Internet multiplayer games in a variety of game modes such as co-operative, deathmatch, team deathmatch and capture the flag (provided via our use of the *ZQuake* "*QuakeWorld*" game engine). The traditional singleplayer gametypes are, of course, supported.
 
-* "Implicit Accessibility"—The use of modern 3D audio and special effects technology to make the game inherently more accessible. This, in turn, means that the difference between the software that the sighted and blind use is dramatically minimised. For all intents and purposes, you'll be playing *the same* game.
+* "Implicit Accessibility"&mdash;The use of modern 3D audio and special effects technology to make the game inherently more accessible. This, in turn, means that the difference between the software that the sighted and blind use is dramatically minimised. For all intents and purposes, you'll be playing *the same* game.
 
 * Accessible level-editing tools. These will allow you to create your own levels ("maps") for the game; something that sighted gamers have been able to do for some time. Coupling this with the fact that you can create your own code modifications easily, *AudioQuake* could be used as a platform for making your own games\!
 
@@ -42,7 +42,7 @@ So, *AudioQuake* is…
 
 ### *Quake*
 
-At first it may seem obvious that *AudioQuake* is, well, *Quake*. This idea, however, has had a profound impact on how the game is designed. At all times, we have tried to maintain the spirit of *Quake*. You will not find a lot of voice-over information because *Quake* didn't have it—our accessibility features are designed to use intuitive techniques and sounds so that you are not distracted from playing the game. We have only added the accessibility features necessary to play the game effectively. To keep things fair, we've not allowed *AudioQuake* players to do anything *Quake* players can't (within reason).
+At first it may seem obvious that *AudioQuake* is, well, *Quake*. This idea, however, has had a profound impact on how the game is designed. At all times, we have tried to maintain the spirit of *Quake*. You will not find a lot of voice-over information because *Quake* didn't have it&mdash;our accessibility features are designed to use intuitive techniques and sounds so that you are not distracted from playing the game. We have only added the accessibility features necessary to play the game effectively. To keep things fair, we've not allowed *AudioQuake* players to do anything *Quake* players can't (within reason).
 
 This design philosophy comes across in the way the accessibility features present themselves in the game. The idea is that an *AudioQuake* player is no different than a *Quake* player, but they have in their possession certain "objects" that provide accessibility features such as enemy detection (the EtherScan RADAR), item detection (the Detector 5000) and navigation (the Navigation Helper). Many features can be toggled on or off according to your individual taste and level of sight.
 
@@ -52,7 +52,7 @@ As *AudioQuake* development brings more of the key features mentioned above into
 
 We have tried our best to make it possible for *AudioQuake* players to use the original *Quake* maps. Currently there are a number of maps from the game that cam be played by blind players. A series of tutorial maps is provided to help you get used to the game and we hope to provide a range of custom-built accessible maps in the future.
 
-In the end, the main point of *AudioQuake* is not to prove that video game accessibility is possible, as this has already been established. The main point is that *community* accessibility is possible—that blind and vision-impaired players can use *the exact same software*, join Internet games and contribute new maps and modifications, just as the sighted are able to.
+In the end, the main point of *AudioQuake* is not to prove that video game accessibility is possible, as this has already been established. The main point is that *community* accessibility is possible&mdash;that blind and vision-impaired players can use *the exact same software*, join Internet games and contribute new maps and modifications, just as the sighted are able to.
 
 #### Not for under-15s
 
@@ -74,7 +74,7 @@ Our reasons for making *AudioQuake* Free are that it should make it easier for p
 
 We're building not just a game, but a framework with which you can create your own games. This framework currently allows you to alter all aspects of the way the game works and sounds, with level editing planned for the future, as we get closer to the 1.0.0 version number.
 
-With a number of commercial game engines now made Open Source, the possibility of making other titles accessible is a reality. Some even use the *Quake* engine—*Half-Life* would make a most amazing and immersive accessible game due to its amazing sounds, AI, story line and massively popular online game modes.
+With a number of commercial game engines now made Open Source, the possibility of making other titles accessible is a reality. Some even use the *Quake* engine&mdash;*Half-Life* would make a most amazing and immersive accessible game due to its amazing sounds, AI, story line and massively popular online game modes.
 
 It is possible that later engines such as *Quake III* and *Unreal* could be made accessible even without access to the engine code. We wanted to produce a Free game, which is why we didn't choose these titles. We also thought that *Quake* would be a good starting point as it marked the dawn of modern game engine design.
 
@@ -98,7 +98,7 @@ Currently at least one of the *Level Description Language (LDL)* maps requires s
 
 ### Buying *Quake*
 
-We recommend that you buy *Quake* so you can use its data with *AudioQuake* (not all the levels are accessible, but a number are—having the full *Quake* data also means you can experience its ambience and use it in your own maps). Whilst there is a Shareware episode of *Quake*, it doesn't permit using custom maps, which *AudioQuake* provides, and the *Level Description Language (LDL)* allows you to create.
+We recommend that you buy *Quake* so you can use its data with *AudioQuake* (not all the levels are accessible, but a number are&mdash;having the full *Quake* data also means you can experience its ambience and use it in your own maps). Whilst there is a Shareware episode of *Quake*, it doesn't permit using custom maps, which *AudioQuake* provides, and the *Level Description Language (LDL)* allows you to create.
 
 You can buy *Quake* online from the following places. Please note that ***AudioQuake* does not support the mission packs**.
 

--- a/audioquake/manuals/user-manual-part02.md
+++ b/audioquake/manuals/user-manual-part02.md
@@ -1,7 +1,7 @@
 <a name="playing-audioquake"></a>
 # Playing *AudioQuake*
 
-This part of the manual is a guide to playing *AudioQuake*. It is aimed at people who have played accessible games such as *Shades of Doom* and *Monkey Business* before—though if you're used to playing 3D/FPS games in general, you should feel at home.
+This part of the manual is a guide to playing *AudioQuake*. It is aimed at people who have played accessible games such as *Shades of Doom* and *Monkey Business* before&mdash;though if you're used to playing 3D/FPS games in general, you should feel at home.
 
 *AudioQuake* has a number of game modes. This part explains only what is common between all game modes. The [Singleplayer game modes](#singleplayer-game-modes) and [Multiplayer game modes](#multiplayer-game-modes) sections tell you more about each individual mode.
 
@@ -57,7 +57,7 @@ This section explains how you can navigate when you're in the game. If you've no
 
 ### Moving around
 
-To move around, use the arrow keys. Turning is implemented in a familiar way to users of accessible games—pressing the arrow keys snaps the player round a certain number of degrees. By default, the player has a 16-point turn (that is to say each tap of the arrow keys will turn you 22.5 degrees in that direction).
+To move around, use the arrow keys. Turning is implemented in a familiar way to users of accessible games&mdash;pressing the arrow keys snaps the player round a certain number of degrees. By default, the player has a 16-point turn (that is to say each tap of the arrow keys will turn you 22.5 degrees in that direction).
 
 A very important move in *Quake* is "strafing". To strafe, hold down <kbd>Alt</kbd> and press-and-hold the <kbd>Left</kbd> or <kbd>Right</kbd> arrow key. This moves you from side-to-side and helps you avoid incoming enemy fire.
 
@@ -73,7 +73,7 @@ To toggle the whole of the navigation subsystem on/off, use the <kbd>N</kbd> key
 
 If turned on, you'll hear a sound to your left, in front of you and to your right to indicate if a [wall](../id1/sound/nav/wall.wav), [slope](../id1/sound/nav/slope.wav) (which could be some steps or a ramp) or a [door](../id1/sound/nav/door.wav) is present near you in any of these directions. The sounds get louder the closer you are to the obstacle in question.
 
-The sound that walls make falls off more quickly than the sound steps/ramps and doors make. Also, side wall warnings are off by default—though you'll always be told about doors and slopes to your left and right. The fact that walls are given lower priority than slopes and doors should allow you to locate the key features of the map more efficiently. You can toggle the announcement of walls to your left and right with the <kbd>E</kbd> key. All obstacle sounds can be turned off with the <kbd>W</kbd> key.
+The sound that walls make falls off more quickly than the sound steps/ramps and doors make. Also, side wall warnings are off by default&mdash;though you'll always be told about doors and slopes to your left and right. The fact that walls are given lower priority than slopes and doors should allow you to locate the key features of the map more efficiently. You can toggle the announcement of walls to your left and right with the <kbd>E</kbd> key. All obstacle sounds can be turned off with the <kbd>W</kbd> key.
 
 ##### Wall hit and touch warnings
 
@@ -91,13 +91,13 @@ Press <kbd>J</kbd> to be told if you can make a jump or a running jump over the 
 
 You can find out how big a drop is by the pitch of the beep. There are 4 classifications:
 
-* Negligible drop—not announced.
+* Negligible drop&mdash;not announced.
 
-* [Small drop](../id1/sound/haz/drop-small.wav)—requires jumping to get over.
+* [Small drop](../id1/sound/haz/drop-small.wav)&mdash;requires jumping to get over.
 
-* [Big drop](../id1/sound/haz/drop-big.wav)—a drop that is too tall for you to jump back out of and get back to where you were before you fell down it.
+* [Big drop](../id1/sound/haz/drop-big.wav)&mdash;a drop that is too tall for you to jump back out of and get back to where you were before you fell down it.
 
-* [Huge drop](../id1/sound/haz/drop-huge.wav)—a drop this big will hurt you if you fall all the way to the ground (note that water will cushion you).
+* [Huge drop](../id1/sound/haz/drop-huge.wav)&mdash;a drop this big will hurt you if you fall all the way to the ground (note that water will cushion you).
 
 To find out what's at the bottom, use the K key. You will get the ["access denied"](../id1/sound/deny.wav) sound if you are too far away or not facing a ledge. If you are successful, you'll be told that the drop is either onto the ground or into water, slime or the dreaded lava.
 
@@ -105,7 +105,7 @@ To find out what's at the bottom, use the K key. You will get the ["access denie
 
 #### Open space detection
 
-This gives you a bit more of a feel for how big the area around you actually is. It will play a [gentle wind](../id1/sound/nav/wind.wav) sound at various points in front of you if there are no walls or other obstacles in that direction. The sounds are generated in a sweep from left to right around you, in response to a pres of the L key. It works as if you were using a mobility cane to scan the area—though it has significantly greater range.
+This gives you a bit more of a feel for how big the area around you actually is. It will play a [gentle wind](../id1/sound/nav/wind.wav) sound at various points in front of you if there are no walls or other obstacles in that direction. The sounds are generated in a sweep from left to right around you, in response to a pres of the L key. It works as if you were using a mobility cane to scan the area&mdash;though it has significantly greater range.
 
 The distance over which obstacles are scanned for is the navigation detection range and is customisable (please read [Customising *AudioQuake*](#customising-audioauake) for more details).
 
@@ -125,9 +125,9 @@ This chapter describes some helpful features that are not tied to, or part of, t
 
 #### Footsteps
 
-Footsteps can tell you a lot—whether you're moving and, if so, how fast. They can be toggled with the letter <kbd>F</kbd> key. As with all other keys, this can be customised.
+Footsteps can tell you a lot&mdash;whether you're moving and, if so, how fast. They can be toggled with the letter <kbd>F</kbd> key. As with all other keys, this can be customised.
 
-When you are totally stuck on an object, you will not be able to move. Consequently your footsteps will stop. If you're scraping along a wall (i.e. caught on it but still moving) you'll hear a [scraping sound](../id1/sound/nav/wall-scrape.wav) as you walk along—you'll also hear the footsteps' speed drop to indicate you're not walking freely.
+When you are totally stuck on an object, you will not be able to move. Consequently your footsteps will stop. If you're scraping along a wall (i.e. caught on it but still moving) you'll hear a [scraping sound](../id1/sound/nav/wall-scrape.wav) as you walk along&mdash;you'll also hear the footsteps' speed drop to indicate you're not walking freely.
 
 If you're stuck on an object, you'll continue to hear the "oomph" sound described above when you try to move in the direction it lies.
 
@@ -143,7 +143,7 @@ This is a helpful feature that will tell you if you've been somewhere before. Yo
 
 To drop a marker, press <kbd>Insert</kbd>. To delete the last one you dropped, press <kbd>Delete</kbd>.
 
-## Creature and hazard detection—the EtherScan RADAR
+## Creature and hazard detection&mdash;the EtherScan RADAR
 
 The EtherScan RADAR ("ESR" as it is known for short) is a device that alerts you to proximity of things. It has two modes, described below.
 
@@ -155,7 +155,7 @@ To toggle monster detection on/off, press <kbd>R</kbd>. This acts as a kind of R
 
 ### Hazard detection
 
-If there is a hazard in front of you—some kind of ledge/drop—you'll be told about it by the navigation helper. If you want to try and jump over the pit, you can use this alternative ESR mode to help you do so. Pressing the <kbd>R</kbd> key again when you have a drop in front of you will make the ESR lock onto it instead of enemies. It automatically falls back to detecting enemies when you lose the lock on the pit (by jumping over it successfully, falling in or just turning and facing another way).
+If there is a hazard in front of you&mdash;some kind of ledge/drop&mdash;you'll be told about it by the navigation helper. If you want to try and jump over the pit, you can use this alternative ESR mode to help you do so. Pressing the <kbd>R</kbd> key again when you have a drop in front of you will make the ESR lock onto it instead of enemies. It automatically falls back to detecting enemies when you lose the lock on the pit (by jumping over it successfully, falling in or just turning and facing another way).
 
 If it can't find a pit, it will just turn the ESR off.
 
@@ -185,7 +185,7 @@ To switch weapons, use the keys <kbd>1</kbd>-<kbd>8</kbd> on they keyboard. You 
 
 From <kbd>1</kbd> to <kbd>8</kbd>, the weapons available in *Quake* are: axe, shotgun, double-barrelled shotgun, nailgun, super nailgun, grenade launcher (grenades are often affectionately known as pineapples), rocket launcher (the "boomstick") and the lightning gun. There are four different types of ammo you can pick up: shells, nails, rockets and cells (the grenade launcher uses rocket ammo).
 
-Some weapons are more effective against certain types of enemy than others—you'll begin to get an idea of how your implements of destruction are working as you play the game. There are also a number of special moves you can do with some of the weapons. Again, you'll begin to learn techniques as you play but to help you on your way, here are the names of some of the most interesting ones are the "rocket jump" and the "pineapple jump". Beware of mixing liquids and electricity, too…
+Some weapons are more effective against certain types of enemy than others&mdash;you'll begin to get an idea of how your implements of destruction are working as you play the game. There are also a number of special moves you can do with some of the weapons. Again, you'll begin to learn techniques as you play but to help you on your way, here are the names of some of the most interesting ones are the "rocket jump" and the "pineapple jump". Beware of mixing liquids and electricity, too…
 
 If you run out of ammo, you'll automatically switch to the next best weapon for which you do have enough for at least 1 shot. For more information on weapons, please consult *Quake*'s `MANUAL.txt` file.
 
@@ -213,12 +213,12 @@ One of *Quake*'s strengths is that it allows total control over which keys do wh
 
 Some extra keys you may be interested in are:
 
-* <kbd>Home</kbd>—To have the last message that was announced repeated, press this key.
+* <kbd>Home</kbd>&mdash;To have the last message that was announced repeated, press this key.
 
-* <kbd>End</kbd>—Pressing this key mutes all currently queued speech.
+* <kbd>End</kbd>&mdash;Pressing this key mutes all currently queued speech.
 
-* <kbd>F10</kbd>—Press to exit *Quake* and return to the *AudioQuake* launcher's main menu.
+* <kbd>F10</kbd>&mdash;Press to exit *Quake* and return to the *AudioQuake* launcher's main menu.
 
-* <kbd>Pause</kbd>—Erm, pauses the game. Press again (or <kbd>Escape</kbd>, or <kbd>Ctrl</kbd>) to un-pause.
+* <kbd>Pause</kbd>&mdash;Erm, pauses the game. Press again (or <kbd>Escape</kbd>, or <kbd>Ctrl</kbd>) to un-pause.
 
 **Note:** You'll find that there are some keys for keeping up with chat messages in multiplayer games. These are discussed later on.

--- a/audioquake/manuals/user-manual-part02.md
+++ b/audioquake/manuals/user-manual-part02.md
@@ -127,7 +127,7 @@ This chapter describes some helpful features that are not tied to, or part of, t
 
 Footsteps can tell you a lot&mdash;whether you're moving and, if so, how fast. They can be toggled with the letter <kbd>F</kbd> key. As with all other keys, this can be customised.
 
-When you are totally stuck on an object, you will not be able to move. Consequently your footsteps will stop. If you're scraping along a wall (i.e. caught on it but still moving) you'll hear a [scraping sound](../id1/sound/nav/wall-scrape.wav) as you walk along&mdash;you'll also hear the footsteps' speed drop to indicate you're not walking freely.
+When you are totally stuck on an object, you will not be able to move. Consequently your footsteps will stop. If you're scraping along a wall (i.e. caught on it but still moving) you'll hear a [scraping sound](../id1/sound/nav/wall-scrape.wav) as you walk along&mdash;you'll also hear the footsteps' speed drop to indicate you're not walking freely.
 
 If you're stuck on an object, you'll continue to hear the "oomph" sound described above when you try to move in the direction it lies.
 

--- a/audioquake/manuals/user-manual-part02.md
+++ b/audioquake/manuals/user-manual-part02.md
@@ -185,7 +185,7 @@ To switch weapons, use the keys <kbd>1</kbd>-<kbd>8</kbd> on they keyboard. You 
 
 From <kbd>1</kbd> to <kbd>8</kbd>, the weapons available in *Quake* are: axe, shotgun, double-barrelled shotgun, nailgun, super nailgun, grenade launcher (grenades are often affectionately known as pineapples), rocket launcher (the "boomstick") and the lightning gun. There are four different types of ammo you can pick up: shells, nails, rockets and cells (the grenade launcher uses rocket ammo).
 
-Some weapons are more effective against certain types of enemy than others&mdash;you'll begin to get an idea of how your implements of destruction are working as you play the game. There are also a number of special moves you can do with some of the weapons. Again, you'll begin to learn techniques as you play but to help you on your way, here are the names of some of the most interesting ones are the "rocket jump" and the "pineapple jump". Beware of mixing liquids and electricity, too…
+Some weapons are more effective against certain types of enemy than others&mdash;you'll begin to get an idea of how your implements of destruction are working as you play the game. There are also a number of special moves you can do with some of the weapons. Again, you'll begin to learn techniques as you play but to help you on your way, here are the names of some of the most interesting ones are the "rocket jump" and the "pineapple jump". Beware of mixing liquids and electricity, too&hellip;
 
 If you run out of ammo, you'll automatically switch to the next best weapon for which you do have enough for at least 1 shot. For more information on weapons, please consult *Quake*'s `MANUAL.txt` file.
 

--- a/audioquake/manuals/user-manual-part03.md
+++ b/audioquake/manuals/user-manual-part03.md
@@ -78,7 +78,7 @@ Choosing which episode to play is done by entering one of the four doors in the 
 
 **Warning:** *AudioQuake* provides fairly decent accessibility on some of the game's maps, but they weren't designed with accessibility in mind, so it's most likely not possible to complete them all.
 
-The maps are named using a format "e*X*m*Y*" where *x* is a number from 1 to 4 and *y* is a number between 1 and 8. Episodes 2 and 3 only have 7 maps so that second (map) number is lower for them. The last map is always the secret one for that episode (i.e. it is found via a secret area on one of the other maps).
+The maps are named using a format "e*X*m*Y*" where *x* is a number from 1 to 4 and *y* is a number between 1 and 8. Episodes 2 and 3 only have 7 maps so that second (map) number is lower for them. The last map is always the secret one for that episode (i.e. it is found via a secret area on one of the other maps).
 
 To load a map in single-player mode, type
 

--- a/audioquake/manuals/user-manual-part03.md
+++ b/audioquake/manuals/user-manual-part03.md
@@ -35,7 +35,7 @@ map agtut01
 
 ```
 
-This takes the game out of multiplayer mode and loads the first tutorial map. You can then play through the entire set of tutorials. Each tutorial map is linked to the next. If you wish to jump into a certain tutorial map, don't\! You can use the save and load features of the game to pause and resume your journey through the tutorial—for example…
+This takes the game out of multiplayer mode and loads the first tutorial map. You can then play through the entire set of tutorials. Each tutorial map is linked to the next. If you wish to jump into a certain tutorial map, don't\! You can use the save and load features of the game to pause and resume your journey through the tutorial&mdash;for example…
 
 ``` screen
 save tutorial

--- a/audioquake/manuals/user-manual-part03.md
+++ b/audioquake/manuals/user-manual-part03.md
@@ -26,7 +26,7 @@ If you want to use the high-contrast versions of the tutorial maps, you can inst
 tuthc
 ```
 
-**Tip:** For power users, the above is equivalent to entering the following three commands…
+**Tip:** For power users, the above is equivalent to entering the following three commands&hellip;
 
 ``` screen
 deathmatch 0
@@ -35,7 +35,7 @@ map agtut01
 
 ```
 
-This takes the game out of multiplayer mode and loads the first tutorial map. You can then play through the entire set of tutorials. Each tutorial map is linked to the next. If you wish to jump into a certain tutorial map, don't\! You can use the save and load features of the game to pause and resume your journey through the tutorial&mdash;for example…
+This takes the game out of multiplayer mode and loads the first tutorial map. You can then play through the entire set of tutorials. Each tutorial map is linked to the next. If you wish to jump into a certain tutorial map, don't\! You can use the save and load features of the game to pause and resume your journey through the tutorial&mdash;for example&hellip;
 
 ``` screen
 save tutorial
@@ -63,7 +63,7 @@ sp
 
 ```
 
-**Tip:** For power users, the above is equivalent to entering the following three commands…
+**Tip:** For power users, the above is equivalent to entering the following three commands&hellip;
 
 ``` screen
 deathmatch 0

--- a/audioquake/manuals/user-manual-part04.md
+++ b/audioquake/manuals/user-manual-part04.md
@@ -286,7 +286,7 @@ The Stats and Servers website is part of the online community surrounding *Audio
 
 When you visit the stats and servers site, you're presented with a number of choices on where to go. The main page lists the sections you can visit, providing a brief description of each one. The most important areas of the site fall under a few categories:
 
-  - Pages containing global ranking tables, based on a number of criteria. They may be frags, efficiency, overall ranking or time-based (e.g. frags for the current day or month).
+  - Pages containing global ranking tables, based on a number of criteria. They may be frags, efficiency, overall ranking or time-based (e.g. frags for the current day or month).
 
   - Detailed stats for each known *AudioQuake* player (accessed via global players list).
 
@@ -304,7 +304,7 @@ To get your stats included, all you need to do is play on any of the public serv
 
 Running your own *AudioQuake* server allows total control over which maps, gametypes and rules you play. It can also be a fun and rewarding thing to do. If you would like to try setting up your own server, we recommend that you have a go – it will provide you with your ideal game setup and other *AudioQuake* players with an extra place to play (if you run a public server).
 
-### Clients and Dedicated vs. Listen Servers
+### Clients and Dedicated vs. Listen Servers
 
 Quake is a "client-server" game. This means that at any time, to play the game you need a client and a server. The client is the program that the user interacts with, that outputs audio/video and captures input (to be used when moving the player or typing in the console). The server runs the game itself. It controls the environment (lifts, buttons) and items in it (powerups, monsters) and keeps track of scoring in multiplayer games. If you're playing a singleplayer game or practice match on your own computer, the client and the server are both running on your computer. If you're playing an Internet multiplayer game, the server could be hundreds of miles away.
 
@@ -318,13 +318,13 @@ Most servers on the Internet are dedicated ones. They try to be as fair as possi
 
 Another advantage to dedicated servers (which is most likely welcomed by anyone setting one up) is that they don't require terribly fancy computers to run on. This is partly because they don't need to perform any rendering of audio/video data, which can take quite a lot of computing power.
 
-### Public vs. Private and Stats Logging
+### Public vs. Private and Stats Logging
 
 This topic and many others is dealt with on the [Stats and Servers site](http://stats.agrip.org.uk/) (in the FAQ section) – be sure to check it out for the latest information.
 
 ### Interacting with the Server Directly
 
-You can do all sorts of things with the server by interacting with its console when you start it. Tasks such as setting the gametype and map, getting status and kicking players (as well as chatting to the players from outside) can be done via the server's console directly. However, this is not always practical (you may be in the game yourself when you want to change the map, for example). In this case, you can use the "remote console" admin feature. It is beyond the scope of this manual to explain, but you can find out a lot about it and many other features by using the approach detailed in [Appendix B, *Finding out More – The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More – The Web is Your Friend!").
+You can do all sorts of things with the server by interacting with its console when you start it. Tasks such as setting the gametype and map, getting status and kicking players (as well as chatting to the players from outside) can be done via the server's console directly. However, this is not always practical (you may be in the game yourself when you want to change the map, for example). In this case, you can use the "remote console" admin feature. It is beyond the scope of this manual to explain, but you can find out a lot about it and many other features by using the approach detailed in [Appendix B, *Finding out More – The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More – The Web is Your Friend!").
 
 It is recommended that you run a dedicated server on Linux, using the [screen](http://www.gnu.org/software/screen/) program. This allows you to safely detatch from the machine without stopping the server. Furthermore, it is recommended that you copy the standard output of the server to a log file (this will help us fix bugs, should they arise).
 
@@ -347,7 +347,7 @@ The port should show up in the Stats and Servers site, but it may be a good idea
 
 #### Map Cycles
 
-You can specify a list of maps in your config file so that the server is not always playing on the same level. The server will move to the next map after each game is over. By making this list circular (i.e. after the last map, we tell the server to start again) we can keep the rotation going.
+You can specify a list of maps in your config file so that the server is not always playing on the same level. The server will move to the next map after each game is over. By making this list circular (i.e. after the last map, we tell the server to start again) we can keep the rotation going.
 
 Here is an example of how you'd set up such a map cycle (or "rotation") in `server.cfg`. Say you have four maps; A, B, C and D. You wish for them all to be used one after the other ad infinitum. Here is what you'd put into the config file:
 
@@ -363,4 +363,4 @@ localinfo D A
 
 ### Admin Tasks
 
-You'll find yourself needing to carry out a number of tasks as an admin. To get the best information on how to do these jobs, please consult [Appendix B, *Finding out More – The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More – The Web is Your Friend!"). Also, please join the mailing list for server admins. We use it to provide a lot of useful information and arrange regular matches.
+You'll find yourself needing to carry out a number of tasks as an admin. To get the best information on how to do these jobs, please consult [Appendix B, *Finding out More – The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More – The Web is Your Friend!"). Also, please join the mailing list for server admins. We use it to provide a lot of useful information and arrange regular matches.

--- a/audioquake/manuals/user-manual-part04.md
+++ b/audioquake/manuals/user-manual-part04.md
@@ -194,7 +194,7 @@ If you're going to be playing a team deathmatch game, you'll probably want to gi
 
 There are two other personalisations you can make regarding your appearance to others in multiplayer games. These are the colour of your character's uniform within the game. The console commands **topcolor** and **bottomcolor** can be used to change these. We mention them here for completeness.
 
-Now you've made yourself a little more unique in the virtual world, it is time to join a game…
+Now you've made yourself a little more unique in the virtual world, it is time to join a game&hellip;
 
 ### Joining a Game
 

--- a/audioquake/manuals/user-manual-part04.md
+++ b/audioquake/manuals/user-manual-part04.md
@@ -46,7 +46,7 @@ The above may take some time, so a timelimit is usually set. This ends the match
 
 ### Team Deathmatch
 
-This mode is similar to the last one but has one main difference: You are not on your own – you can have an epic battle in which all the players on your team are against all the players/bots on the enemy team\!
+This mode is similar to the last one but has one main difference: You are not on your own&mdash;you can have an epic battle in which all the players on your team are against all the players/bots on the enemy team\!
 
 Team Deathmatch games are started in the same way as regular deathmatches and can have frag and time limits, except that the fraglimit is the number of frags that a team must score to win.
 
@@ -102,7 +102,7 @@ map agdm01
 
 ```
 
-When you're in the map, you will notice that there is not much going on. To create ("spawn") a bot, press the comma or dot key on your keyboard. An enemy will be provided for you to play with. When either of you is fragged, you'll "respawn" at a random teleporter in the map, ready to resume the game – but with a slightly decreased frag count (your score).
+When you're in the map, you will notice that there is not much going on. To create ("spawn") a bot, press the comma or dot key on your keyboard. An enemy will be provided for you to play with. When either of you is fragged, you'll "respawn" at a random teleporter in the map, ready to resume the game&mdash;but with a slightly decreased frag count (your score).
 
 Please note that the bots act like players; they use all the weapons and navigate the map on their own. In other words, they're tough\!
 
@@ -130,7 +130,7 @@ timelimit 10
 
 ### Team Deathmatch
 
-Team Deathmatch games are started in the same way as regular deathmatches and can have frag and time limits. The previous section explains how to set these up. The important thing to note about starting team deathmatches is that the teamplay mode must be set before you open the map and start spawning bots. This can be achieved by using the simple **teamdm** console command. As above, you can take more control over the game mode and may by setting them manually – for example:
+Team Deathmatch games are started in the same way as regular deathmatches and can have frag and time limits. The previous section explains how to set these up. The important thing to note about starting team deathmatches is that the teamplay mode must be set before you open the map and start spawning bots. This can be achieved by using the simple **teamdm** console command. As above, you can take more control over the game mode and may by setting them manually&mdash;for example:
 
 ``` screen
 teamplay 1
@@ -171,7 +171,7 @@ Now you know how to play the various game modes and have had some practice with 
 
 ### Multiplayer Basics
 
-When you play any of the gametypes (singleplayer or practice matches) mentioned above, it is your computer that controls all aspects of the game – from the generation of game sounds to the behaviour of the monsters or bots you're playing the game with. When you play a game over the Internet, this isn't the case. What happens is that your computer connects to another computer which acts as a *server*. The server manages connections from all of the players and controls most game-related things (such as keeping track of players' scores and movements round a map). Your computer still takes care of dealing with your input and playing back sounds, but it doesn't control the match being played in any way.
+When you play any of the gametypes (singleplayer or practice matches) mentioned above, it is your computer that controls all aspects of the game&mdash;from the generation of game sounds to the behaviour of the monsters or bots you're playing the game with. When you play a game over the Internet, this isn't the case. What happens is that your computer connects to another computer which acts as a *server*. The server manages connections from all of the players and controls most game-related things (such as keeping track of players' scores and movements round a map). Your computer still takes care of dealing with your input and playing back sounds, but it doesn't control the match being played in any way.
 
 So, to join an Internet game, you need to connect to a server that other people may also connect to. There are many *QuakeWorld* servers out there but most don't provide the accessibility features that *AudioQuake* does. You'll need to connect to a specific *AudioQuake* server in order to play the game.
 
@@ -198,7 +198,7 @@ Now you've made yourself a little more unique in the virtual world, it is time t
 
 ### Joining a Game
 
-We have set up a few game servers under the AGRIP banner (details can be found in an appendix), but you're certainly not restricted to playing *AudioQuake* on one of these – in fact, we encourage you to seek out other servers on the Internet to play on and/or to set up a server of your own. This can be especially rewarding if you know a few people that you'd like to play the game with. Anyone who sets up a server (covered later in the manual) can have it automatically advertised to every other *AudioQuake* player, via the AGRIP master server. This keeps a list of all active *AudioQuake* game servers on the Internet. By using a program that searches this list (known as a *server browser*), you can find a game to join. As server admins are free to chose any gametype and selection of maps that their server runs, you should be able to find a match that suits your tastes.
+We have set up a few game servers under the AGRIP banner (details can be found in an appendix), but you're certainly not restricted to playing *AudioQuake* on one of these&mdash;in fact, we encourage you to seek out other servers on the Internet to play on and/or to set up a server of your own. This can be especially rewarding if you know a few people that you'd like to play the game with. Anyone who sets up a server (covered later in the manual) can have it automatically advertised to every other *AudioQuake* player, via the AGRIP master server. This keeps a list of all active *AudioQuake* game servers on the Internet. By using a program that searches this list (known as a *server browser*), you can find a game to join. As server admins are free to chose any gametype and selection of maps that their server runs, you should be able to find a match that suits your tastes.
 
 To search for games over the whole Internet, you can use either the *AudioQuake* Stats and Servers site, or a command-line program called QStat. This is a very powerful, popular and accessible tool, which allows you fine control over your searches. For more information on using QStat, visit it's web site at <http://www.qstat.org/>. Information on the *AudioQuake* Stats and Servers web site can be found [in the next chapter](#mmodes-statsnservers "Chapter 15. *AudioQuake* Stats and Servers Website").
 
@@ -228,7 +228,7 @@ say_team message
 
 ```
 
-**Warning:** Be nice to the other people on the server – if you're not, the server admin has the power to *kick* you from the game and ban you from reconnecting\!
+**Warning:** Be nice to the other people on the server&mdash;if you're not, the server admin has the power to *kick* you from the game and ban you from reconnecting\!
 
 #### Chat History
 
@@ -302,13 +302,13 @@ To get your stats included, all you need to do is play on any of the public serv
 
 ## Setting up and Running your own Server
 
-Running your own *AudioQuake* server allows total control over which maps, gametypes and rules you play. It can also be a fun and rewarding thing to do. If you would like to try setting up your own server, we recommend that you have a go – it will provide you with your ideal game setup and other *AudioQuake* players with an extra place to play (if you run a public server).
+Running your own *AudioQuake* server allows total control over which maps, gametypes and rules you play. It can also be a fun and rewarding thing to do. If you would like to try setting up your own server, we recommend that you have a go&mdash;it will provide you with your ideal game setup and other *AudioQuake* players with an extra place to play (if you run a public server).
 
 ### Clients and Dedicated vs. Listen Servers
 
 Quake is a "client-server" game. This means that at any time, to play the game you need a client and a server. The client is the program that the user interacts with, that outputs audio/video and captures input (to be used when moving the player or typing in the console). The server runs the game itself. It controls the environment (lifts, buttons) and items in it (powerups, monsters) and keeps track of scoring in multiplayer games. If you're playing a singleplayer game or practice match on your own computer, the client and the server are both running on your computer. If you're playing an Internet multiplayer game, the server could be hundreds of miles away.
 
-When setting up a server, the most fundamental decision is what type of server to set up. Dedicated servers are programs that only perform the task of running the game. They do not output any audio/video and don't allow you to play a game on them directly. Listen servers, however, act as the singleplayer and offline game modes do – except that they allow connections from other players on the Internet. From your point-of-view, this makes listen servers "feel" very similar to the on or offline games you've been accustomed to playing up until now.
+When setting up a server, the most fundamental decision is what type of server to set up. Dedicated servers are programs that only perform the task of running the game. They do not output any audio/video and don't allow you to play a game on them directly. Listen servers, however, act as the singleplayer and offline game modes do&mdash;except that they allow connections from other players on the Internet. From your point-of-view, this makes listen servers "feel" very similar to the on or offline games you've been accustomed to playing up until now.
 
 #### Why Use Dedicated Servers?
 
@@ -320,11 +320,11 @@ Another advantage to dedicated servers (which is most likely welcomed by anyone 
 
 ### Public vs. Private and Stats Logging
 
-This topic and many others is dealt with on the [Stats and Servers site](http://stats.agrip.org.uk/) (in the FAQ section) – be sure to check it out for the latest information.
+This topic and many others is dealt with on the [Stats and Servers site](http://stats.agrip.org.uk/) (in the FAQ section)&mdash;be sure to check it out for the latest information.
 
 ### Interacting with the Server Directly
 
-You can do all sorts of things with the server by interacting with its console when you start it. Tasks such as setting the gametype and map, getting status and kicking players (as well as chatting to the players from outside) can be done via the server's console directly. However, this is not always practical (you may be in the game yourself when you want to change the map, for example). In this case, you can use the "remote console" admin feature. It is beyond the scope of this manual to explain, but you can find out a lot about it and many other features by using the approach detailed in [Appendix B, *Finding out More – The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More – The Web is Your Friend!").
+You can do all sorts of things with the server by interacting with its console when you start it. Tasks such as setting the gametype and map, getting status and kicking players (as well as chatting to the players from outside) can be done via the server's console directly. However, this is not always practical (you may be in the game yourself when you want to change the map, for example). In this case, you can use the "remote console" admin feature. It is beyond the scope of this manual to explain, but you can find out a lot about it and many other features by using the approach detailed in [Appendix B, *Finding out More&mdash;The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More&mdash;The Web is Your Friend!").
 
 It is recommended that you run a dedicated server on Linux, using the [screen](http://www.gnu.org/software/screen/) program. This allows you to safely detatch from the machine without stopping the server. Furthermore, it is recommended that you copy the standard output of the server to a log file (this will help us fix bugs, should they arise).
 
@@ -359,8 +359,8 @@ localinfo D A
 
 ```
 
-**Note:** You can only specify two maps with each use of **localinfo** – you're effectively telling the game which map is next given the current one.
+**Note:** You can only specify two maps with each use of **localinfo**&mdash;you're effectively telling the game which map is next given the current one.
 
 ### Admin Tasks
 
-You'll find yourself needing to carry out a number of tasks as an admin. To get the best information on how to do these jobs, please consult [Appendix B, *Finding out More – The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More – The Web is Your Friend!"). Also, please join the mailing list for server admins. We use it to provide a lot of useful information and arrange regular matches.
+You'll find yourself needing to carry out a number of tasks as an admin. To get the best information on how to do these jobs, please consult [Appendix B, *Finding out More&mdash;The Web is Your Friend\!*](#ref-weblinks "Appendix B. Finding out More&mdash;The Web is Your Friend!"). Also, please join the mailing list for server admins. We use it to provide a lot of useful information and arrange regular matches.

--- a/audioquake/manuals/user-manual-part05.md
+++ b/audioquake/manuals/user-manual-part05.md
@@ -6,13 +6,13 @@ There are quite a few maps supplied with *AudioQuake* that are extra to those th
 
 ## Deathmatch/team deathmatch maps
 
-The AGRIP deathmatch maps all begin with "agdm", then have a number. Some of them end with a letter—"t" indicates the map is a 1on1 arena and "l" indicates a large map.
+The AGRIP deathmatch maps all begin with "agdm", then have a number. Some of them end with a letter&mdash;"t" indicates the map is a 1on1 arena and "l" indicates a large map.
 
 ### agdm01: The Melee
 
 This is a simple map with a large central rectangular room surrounded by a corridor. There is a door on each side of the central room into this corridor (these doors are at one or other extreme of each side; not in the middle). Opposite the middle of each side of the central room, across the corridor, are short corridors with spawnpoints at the ends. You therefore begin the game facing a side of the large central room.
 
-### agdm01t: The Melee—1on1 Edition
+### agdm01t: The Melee&mdash;1on1 Edition
 
 This map is as above, but has been adapted for two-player "tournament" games by cutting the number of doors onto the central room, and the number of spawnpoints, from 4 to 2.
 
@@ -22,6 +22,6 @@ A large building with 4 levels. There are stairs between each level that announc
 
 The stairs are round the edge of each floor and are arranged such that when you have gone up one set of stairs, you can follow the side of the floor you're around to find the next set.
 
-### agdm02l: Halls of Retribution—Warring Factions Remix
+### agdm02l: Halls of Retribution&mdash;Warring Factions Remix
 
 As in the previous level, but there are two buildings with four floors. This may one day make an excellent "Capture The Flag" map!

--- a/audioquake/manuals/user-manual-part06.md
+++ b/audioquake/manuals/user-manual-part06.md
@@ -19,9 +19,9 @@ In this part, you'll learn how to change settings such as these and more.
 
 There are two files that you can edit to customise the game. The game runs through the contents of these files when it starts up.
 
-* `autoexec.cfg`—by convention, this is the place where all *AudioQuake*-specific settings are kept. As the game starts, it reads this file and acts on the commands found in it.
+* `autoexec.cfg`&mdash;by convention, this is the place where all *AudioQuake*-specific settings are kept. As the game starts, it reads this file and acts on the commands found in it.
 
-* `config.cfg`—contains general *Quake* settings. The curious may want to read this file too, but it is beyond the scope of this section.
+* `config.cfg`&mdash;contains general *Quake* settings. The curious may want to read this file too, but it is beyond the scope of this section.
 
 You can open these files for editing via the launcher. They're plain text files. They have a number of sections and many comments (indicated by lines starting with two forward slashes) in it to explain what each individual setting actually does. This section doesn't repeat what is written in the file, but gives a general overview of what each section of the file is for.
 

--- a/audioquake/manuals/user-manual-part06.md
+++ b/audioquake/manuals/user-manual-part06.md
@@ -11,7 +11,7 @@ As has been touched on before, you are strongly encouraged to tailor the way *Au
 
 * The keys you press to use any of the navigation aids/devices.
 
-* How the spoken interface works – changing voices or using hardware synthesisers or Braille displays.
+* How the spoken interface works&mdash;changing voices or using hardware synthesisers or Braille displays.
 
 In this part, you'll learn how to change settings such as these and more.
 
@@ -49,4 +49,4 @@ Bindings work by specifying a key and then the command that key is meant to acti
 
 ### Aliases
 
-As mentioned above, aliases exist to provide human-readable equivalents to the commands *Quake* actually uses. You don't need to edit this section – it is maintained by us for each release. It only exists to make configuration easier.
+As mentioned above, aliases exist to provide human-readable equivalents to the commands *Quake* actually uses. You don't need to edit this section&mdash;it is maintained by us for each release. It only exists to make configuration easier.

--- a/audioquake/manuals/user-manual-part07-b.md
+++ b/audioquake/manuals/user-manual-part07-b.md
@@ -10,7 +10,7 @@ Depending on how your browser is set up, you should be able to listen to these s
 
 This section explains the meaning of the various toggle sounds used in the game.
 
-| Sound                                        | Description                                                         | Played when…                                                                              |
+| Sound                                        | Description                                                         | Played when&hellip;                                                                              |
 | :------------------------------------------- | :------------------------------------------------------------------ | :---------------------------------------------------------------------------------------- |
 | [On](../id1/sound/toggles/on.wav)            | The generic "item is activated" sound.                              | Played when any device (for example the ESR, D5k or side hazard detection) is turned on.  |
 | [Off](../id1/sound/toggles/off.wav)          | The generic "item has been de-activated" sound.                     | Played when any device (for example the ESR, D5k or side hazard detection) is turned off. |
@@ -22,7 +22,7 @@ This section explains the meaning of the sounds that the navigation helper makes
 
 #### Structures
 
-| Sound                                               | Description                                                                           | Played when…                                                                                                                                                                            |
+| Sound                                               | Description                                                                           | Played when&hellip;                                                                                                                                                                            |
 | :-------------------------------------------------- | :------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Wall](../id1/sound/nav/wall.wav)                   | Sound indicating a wall has been detected.                                            | Played when there is a wall near you (at a volume proportional to your distance from it). Walls are "sounded" at half the volume of stairs and doors (to stop them getting in the way). |
 | [Slope](../id1/sound/nav/slope.wav)                 | Sound indicating a up or downwards slope (or set of stairs) has been detected.        | Played when there is a slope near you (at a volume proportional to your distance from it).                                                                                              |
@@ -33,14 +33,14 @@ This section explains the meaning of the sounds that the navigation helper makes
 
 #### Vertical movement
 
-| Sound                             | Description                                          | Played when…                                        |
+| Sound                             | Description                                          | Played when&hellip;                                        |
 | :-------------------------------- | :--------------------------------------------------- | :-------------------------------------------------- |
 | [Up](../id1/sound/nav/up.wav)     | This sound indicates you're going up in the world.   | Played when you go up stairs, slopes or on lifts.   |
 | [Down](../id1/sound/nav/down.wav) | This sound indicates you're going down in the world. | Played when you go down stairs, slopes or on lifts. |
 
 #### Hazard (drop/ledge) warnings
 
-| Sound                                         | Description             | Played when…                                                                                                   |
+| Sound                                         | Description             | Played when&hellip;                                                                                                   |
 | :-------------------------------------------- | :---------------------- | :------------------------------------------------------------------------------------------------------------- |
 | [Small drop](../id1/sound/haz/drop-small.wav) | Indicates a small drop. | Played when a small drop is detected near you (and hazard warnings and/or side hazard warnings are turned on). |
 | [Big drop](../id1/sound/haz/drop-big.wav)     | Indicates a big drop.   | Played when a big drop is detected near you (and hazard warnings and/or side hazard warnings are turned on).   |
@@ -60,7 +60,7 @@ This section explains the meaning of sounds made by the independent navigation a
 
 #### Waypoint marker sounds
 
-| Sound                                               | Description                               | Played when…                                                                                                                                                                                   |
+| Sound                                               | Description                               | Played when&hellip;                                                                                                                                                                                   |
 | :-------------------------------------------------- | :---------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Marker homing signal](../id1/sound/nav/marker.wav) | Emanates from the marker's location.      | This lets you know where a marker is. When you touch a marker, you'll be told which waypoint number it is (the number increases with every marker you add).                                    |
 | [Denied](../id1/sound/deny.wav)                     | Indicates that an action is not possible. | This sound is used in a number of places to let you know that you can't do something. In this case, it is played when you press the "delete last marker" key and there is no marker to delete. |
@@ -73,7 +73,7 @@ When you activate the compass, you will be told the name of the direction you're
 
 This section explains the meaning of the sounds the D5k makes.
 
-| Sound                                                   | Description                                                                                                                                                       | Played when…                                                                                                 |
+| Sound                                                   | Description                                                                                                                                                       | Played when&hellip;                                                                                                 |
 | :------------------------------------------------------ | :---------------------------------------------------------------------------------------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------------------- |
 | (standard *Quake* sounds)                                 | The *Quake* "item activation" sounds (such as health, ammo, armour, weapon or power-up pickup sounds) are played to indicate what type of object has been detected. | The sounds are played when you're near an object (at a volume proportional to your distance from it).        |
 | [Backpack](../id1/sound/d5k/backpack.wav)               | A dropped backpack. (*Quake* didn't have a sound for these.)                                                                                                        | Played when a dropped backpack is near you. Monsters drop them when they die (if they've not been exploded). |
@@ -93,7 +93,7 @@ This section explains the meaning of the sounds that the ESR makes.
 
 #### Monster indication sounds
 
-| Sound                                                          | Description                                                                      | Played when…                                                                |
+| Sound                                                          | Description                                                                      | Played when&hellip;                                                                |
 | :------------------------------------------------------------- | :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
 | [Monster on lower level](../id1/sound/esr/monster-lower.wav)   | Sound indicating that a monster is at a lower level (elevation) to the player.   | Played when a monster is detected and is on the lower level as the player.  |
 | [Monster on same level](../id1/sound/esr/monster-same.wav)     | Sound indicating that a monster is at a similar level (elevation) to the player. | Played when a monster is detected and is on the same level as the player.   |
@@ -101,7 +101,7 @@ This section explains the meaning of the sounds that the ESR makes.
 
 #### Enemy (player or bot) indication sounds
 
-| Sound                                                      | Description                                                                    | Played when…                                                              |
+| Sound                                                      | Description                                                                    | Played when&hellip;                                                              |
 | :--------------------------------------------------------- | :----------------------------------------------------------------------------- | :------------------------------------------------------------------------ |
 | [Enemy on lower level](../id1/sound/esr/enemy-lower.wav)   | Sound indicating that a enemy is at a lower level (elevation) to the player.   | Played when a enemy is detected and is on the lower level as the player.  |
 | [Enemy on same level](../id1/sound/esr/enemy-same.wav)     | Sound indicating that a enemy is at a similar level (elevation) to the player. | Played when a enemy is detected and is on the same level as the player.   |
@@ -109,7 +109,7 @@ This section explains the meaning of the sounds that the ESR makes.
 
 #### Friend (player or bot) indication sounds
 
-| Sound                                                        | Description                                                                     | Played when…                                                               |
+| Sound                                                        | Description                                                                     | Played when&hellip;                                                               |
 | :----------------------------------------------------------- | :------------------------------------------------------------------------------ | :------------------------------------------------------------------------- |
 | [Friend on lower level](../id1/sound/esr/friend-lower.wav)   | Sound indicating that a friend is at a lower level (elevation) to the player.   | Played when a friend is detected and is on the lower level as the player.  |
 | [Friend on same level](../id1/sound/esr/friend-same.wav)     | Sound indicating that a friend is at a similar level (elevation) to the player. | Played when a friend is detected and is on the same level as the player.   |

--- a/audioquake/manuals/user-manual-part07-b.md
+++ b/audioquake/manuals/user-manual-part07-b.md
@@ -20,7 +20,7 @@ This section explains the meaning of the various toggle sounds used in the game.
 
 This section explains the meaning of the sounds that the navigation helper makes.
 
-#### Structures
+#### Structures
 
 | Sound                                               | Description                                                                           | Played when&hellip;                                                                                                                                                                            |
 | :-------------------------------------------------- | :------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -38,7 +38,7 @@ This section explains the meaning of the sounds that the navigation helper makes
 | [Up](../id1/sound/nav/up.wav)     | This sound indicates you're going up in the world.   | Played when you go up stairs, slopes or on lifts.   |
 | [Down](../id1/sound/nav/down.wav) | This sound indicates you're going down in the world. | Played when you go down stairs, slopes or on lifts. |
 
-#### Hazard (drop/ledge) warnings
+#### Hazard (drop/ledge) warnings
 
 | Sound                                         | Description             | Played when&hellip;                                                                                                   |
 | :-------------------------------------------- | :---------------------- | :------------------------------------------------------------------------------------------------------------- |
@@ -50,7 +50,7 @@ This section explains the meaning of the sounds that the navigation helper makes
 
 When you ask if you can make a jump, you'll either be told (via speech or Braille, depending on how you've set *AudioQuake* up) that you can make it with a normal jump or you'll need to do a running jump.
 
-If this information is not available (i.e. if there is no jump in front of you, or you're too far away from one), you'll hear this generic ["access denied"](../id1/sound/deny.wav)-type sound.
+If this information is not available (i.e. if there is no jump in front of you, or you're too far away from one), you'll hear this generic ["access denied"](../id1/sound/deny.wav)-type sound.
 
 You'll also hear the above sound if you ask for a description of what lies in the drop (ground, water, slime or lava) and there is no drop in front of you or you are too far away from one.
 
@@ -91,7 +91,7 @@ If you try to use a weapon you don't yet possess, you'll hear this ["access deni
 
 This section explains the meaning of the sounds that the ESR makes.
 
-#### Monster indication sounds
+#### Monster indication sounds
 
 | Sound                                                          | Description                                                                      | Played when&hellip;                                                                |
 | :------------------------------------------------------------- | :------------------------------------------------------------------------------- | :-------------------------------------------------------------------------- |
@@ -107,7 +107,7 @@ This section explains the meaning of the sounds that the ESR makes.
 | [Enemy on same level](../id1/sound/esr/enemy-same.wav)     | Sound indicating that a enemy is at a similar level (elevation) to the player. | Played when a enemy is detected and is on the same level as the player.   |
 | [Enemy on higher level](../id1/sound/esr/enemy-higher.wav) | Sound indicating that a enemy is at a higher level (elevation) to the player.  | Played when a enemy is detected and is on the higher level as the player. |
 
-#### Friend (player or bot) indication sounds
+#### Friend (player or bot) indication sounds
 
 | Sound                                                        | Description                                                                     | Played when&hellip;                                                               |
 | :----------------------------------------------------------- | :------------------------------------------------------------------------------ | :------------------------------------------------------------------------- |

--- a/ldl/tutorial.md
+++ b/ldl/tutorial.md
@@ -51,7 +51,7 @@ The operating principle of LDL is that we start with as high-level a description
 
 LDL&mdash;the code&mdash;is actually a chain as mentioned above. Each stage is quite separate and the whole thing works by feeding the output of one into the next, until we have our final answer&mdash;the *.map* file.
 
-You start by writing a pretty high-level XML file that describes your map (later we plan to add even easier ways to get data into the system, such as natural language, or an interactive editor program but for now we need to test the basic premise). An XML file is just a plain text file (think similar to HTML if you've used that before), which you can edit with any text editor (e.g. Notepad, Notepad++, ViM, &hellip;)
+You start by writing a pretty high-level XML file that describes your map (later we plan to add even easier ways to get data into the system, such as natural language, or an interactive editor program but for now we need to test the basic premise). An XML file is just a plain text file (think similar to HTML if you've used that before), which you can edit with any text editor (e.g. Notepad, Notepad++, ViM, &hellip;)
 
 The workflow for using LDL is as follows.
 
@@ -71,7 +71,7 @@ The test release is focused on describing the spaces and making simple deathmatc
 
 * Allows you to describe rooms&mdash;their size and style (which causes texturing and lighting to be automatically applied so that sighted people can play your maps too).
 
-* Allows you to specify how rooms are connected (directly) to each other&mdash;i.e. you can specify that a given room is positioned north of another room and that there should be a door between them and both rooms will be positioned correctly&mdash;including at the right height&mdash;and the door&mdash;and any required stairs or an elevation platform&mdash;inserted.
+* Allows you to specify how rooms are connected (directly) to each other&mdash;i.e. you can specify that a given room is positioned north of another room and that there should be a door between them and both rooms will be positioned correctly&mdash;including at the right height&mdash;and the door&mdash;and any required stairs or an elevation platform&mdash;inserted.
 
 * Placement of items within rooms (such as player start points and weapons) on a compass directions system (this is planned to be expanded into percentage-based coordinates in the future).
 
@@ -87,7 +87,7 @@ It does have some limitations, though&hellip;
 
 Here are some features that would be fairly possible given the current foundations&hellip;
 
-* Higher-level descriptions&mdash;giving you the ability to say roughly where some rooms are in 3D space and the programs working out the best way to link them (i.e. with corridors, stairs or lifts).
+* Higher-level descriptions&mdash;giving you the ability to say roughly where some rooms are in 3D space and the programs working out the best way to link them (i.e. with corridors, stairs or lifts).
 
 * Providing a natural language-like interface. Currently the description is written in a type of XML file, but it would be easy to use something similar but lighter, like JSON, and quite do-able to expand to more natural language, and to provide level-editing programs based on the format.
 
@@ -464,7 +464,7 @@ This is very similar to the example above (*tut05*), however, we have added two 
 
    Valid positions are: "tl" (top left), "t" (top centre), "tr" (top right), "r" (right), "br" (bottom right), "b" (bottom centre&mdash;which is the default), "bl" (bottom left) and "c" (centre).
 
-* **elevtype** When you specify that the connecting hole/door is to be placed somewhere other than at ground level on the wall, it might be necessary to provide some means for the player to access the hole&mdash;i.e. stairs or a "plat" (lifting platform). You will be warned when this may be necessary, but as it's a design decision and you may not wish the player to be granted access through this route, you can specify "none" to disable the creation of such a device.
+* **elevtype** When you specify that the connecting hole/door is to be placed somewhere other than at ground level on the wall, it might be necessary to provide some means for the player to access the hole&mdash;i.e. stairs or a "plat" (lifting platform). You will be warned when this may be necessary, but as it's a design decision and you may not wish the player to be granted access through this route, you can specify "none" to disable the creation of such a device.
 
 Have a go running this map: walk straight forward and you will find some stairs. Carry on and you'll go up into the second room.
 
@@ -527,7 +527,7 @@ You can specify sizes ("small", "med" and so on) in the `extent` attribute, as y
 
 #### Vertical connections to other rooms
 
-It is possible for you to position one room entirely on top of or underneath another and link them with connections as discussed earlier, though you'd use "u" (up) and "d" (down) to identify the walls the connections lie on. Currently it is not possible to make elevation devices for these connections (e.g. a plat).
+It is possible for you to position one room entirely on top of or underneath another and link them with connections as discussed earlier, though you'd use "u" (up) and "d" (down) to identify the walls the connections lie on. Currently it is not possible to make elevation devices for these connections (e.g. a plat).
 
 Another thing that could be done in future is supporting teleporters, so you could move between rooms instantaneously.
 
@@ -545,7 +545,7 @@ Another thing that could be done in future is supporting teleporters, so you cou
 
 * Items are placed in rooms according to the same compass direction scheme.
 
-* When assigning sizes to things like rooms, we may say "large" or, if we want to be more precise, specify the size in each of the 3 dimensions of width, depth and height, separated by spaces&mdash;e.g. "medium large medium". When facing north in a room, its width is the distance from your left to your right; its depth is the distance from back to front and its height is vertical distance between its floor and ceiling.
+* When assigning sizes to things like rooms, we may say "large" or, if we want to be more precise, specify the size in each of the 3 dimensions of width, depth and height, separated by spaces&mdash;e.g. "medium large medium". When facing north in a room, its width is the distance from your left to your right; its depth is the distance from back to front and its height is vertical distance between its floor and ceiling.
 
 ## Tricks and treats
 

--- a/ldl/tutorial.md
+++ b/ldl/tutorial.md
@@ -51,7 +51,7 @@ The operating principle of LDL is that we start with as high-level a description
 
 LDL&mdash;the code&mdash;is actually a chain as mentioned above. Each stage is quite separate and the whole thing works by feeding the output of one into the next, until we have our final answer&mdash;the *.map* file.
 
-You start by writing a pretty high-level XML file that describes your map (later we plan to add even easier ways to get data into the system, such as natural language, or an interactive editor program but for now we need to test the basic premise). An XML file is just a plain text file (think similar to HTML if you've used that before), which you can edit with any text editor (e.g. Notepad, Notepad++, ViM, …)
+You start by writing a pretty high-level XML file that describes your map (later we plan to add even easier ways to get data into the system, such as natural language, or an interactive editor program but for now we need to test the basic premise). An XML file is just a plain text file (think similar to HTML if you've used that before), which you can edit with any text editor (e.g. Notepad, Notepad++, ViM, &hellip;)
 
 The workflow for using LDL is as follows.
 
@@ -75,7 +75,7 @@ The test release is focused on describing the spaces and making simple deathmatc
 
 * Placement of items within rooms (such as player start points and weapons) on a compass directions system (this is planned to be expanded into percentage-based coordinates in the future).
 
-It does have some limitations, though…
+It does have some limitations, though&hellip;
 
 * It doesn't support non-rectangular rooms (sorry, my geometry sucks; but you can still make a lot of different overall shapes of interconnected spaces, even with this limitation).
 
@@ -85,7 +85,7 @@ It does have some limitations, though…
 
 ### Possible and blue sky features
 
-Here are some features that would be fairly possible given the current foundations…
+Here are some features that would be fairly possible given the current foundations&hellip;
 
 * Higher-level descriptions&mdash;giving you the ability to say roughly where some rooms are in 3D space and the programs working out the best way to link them (i.e. with corridors, stairs or lifts).
 
@@ -135,7 +135,7 @@ Let's start with a very simple example map.
 </map>
 ```
 
-That's the simplest map you can make with LDL that can be played. Let’s take a look at each line and see what it does…
+That's the simplest map you can make with LDL that can be played. Let’s take a look at each line and see what it does&hellip;
 
 ```xml
 <map name='tut01' style='base'>
@@ -153,7 +153,7 @@ This starts our map off; it's an XML *element* called "map". Elements are writte
 
 As well as having attributes, an element can contain other elements. When we get to the end of the map, we must *close* the map element with `</map>` (this is much like the starting tag, but the first thing within the angle-brackets is a forward slash).
 
-Back to the map file…
+Back to the map file&hellip;
 
 ```xml
 <room id='start'>
@@ -496,7 +496,7 @@ Say you have two rooms, at different heights and you want to make a connection b
 
 We have two rooms&mdash;"start" and "other" as ever. We will position "other" to the north of "start", also as ever. This time, though, we will place a corridor between the two. The corridor will be not very wide, quite long and quite tall so that it can accommodate the change in height from "start" to "other".
 
-As the corridor will be connecting "start" and "other" we'll give it the ID "start2other". This quickly identifies it as a corridor. Here is the map…
+As the corridor will be connecting "start" and "other" we'll give it the ID "start2other". This quickly identifies it as a corridor. Here is the map&hellip;
 
 ```xml
 <map name='tut11' style='base'>
@@ -515,7 +515,7 @@ As the corridor will be connecting "start" and "other" we'll give it the ID "sta
 
 When you enter this map, you'll find a door in front of you and then a corridor, which has a set of steps at the end that lead (without a door) into a room with the rocket launcher.
 
-But those steps are very steep and&mdash;as you're using the entirety of "start2other" as a corridor&mdash;it would be much better if those steps filled the whole room rather than just a small part of it. You can make this happen, as follows…
+But those steps are very steep and&mdash;as you're using the entirety of "start2other" as a corridor&mdash;it would be much better if those steps filled the whole room rather than just a small part of it. You can make this happen, as follows&hellip;
 
 ```xml
 <con wall='n' target='other' pos='t' elevtype='stairs' extent='+' />

--- a/ldl/tutorial.md
+++ b/ldl/tutorial.md
@@ -6,7 +6,7 @@ The AGRIP *Level Description Language*, or LDL, is a text-based format that allo
 
 OK, whilst *Quake* is now ancient (but still a milestone in gaming), the techniques here could be applied to newer engines in much the same way; would love to see, or even help, that happen. In the meantime, you can still use this to make and explore your own somewhat-simplistically-shaped-but-nonetheless-3D worlds! :-)
 
-**The document does talk about possible future major features; it's unlikely these will be implemented in the current context of the game of *Quake*, but they could be if the system is brought to a more modern engine—if you're interested in helping us do this, please get in touch.**
+**The document does talk about possible future major features; it's unlikely these will be implemented in the current context of the game of *Quake*, but they could be if the system is brought to a more modern engine&mdash;if you're interested in helping us do this, please get in touch.**
 
 There are, however, a couple of new features that did get added...
 
@@ -21,7 +21,7 @@ How would one go about making maps for *Quake* before LDL? If you just want to f
 
 1. Level, or map, design would be done with a graphical CAD-like program that provides tools to draw the shapes of the component parts of the map's rooms on the screen. This typically presents four views in panes: one from each elevation (top, side, erm, other side?) and a 3D in-game style view that you can move around with a floating camera (without the constraints of things like gravity or solid walls) to get a better idea of your creation.
 
-2. The shapes you draw—brushes—would make up the rooms in the map. It works like building blocks and you have to put many blocks together to make a single room—one for the floor, ceiling and all of the sides. If you wanted to put a hole in a wall (for a door, for example), you would have to build the brushes around the space where you wanted the hole to be.
+2. The shapes you draw&mdash;brushes&mdash;would make up the rooms in the map. It works like building blocks and you have to put many blocks together to make a single room&mdash;one for the floor, ceiling and all of the sides. If you wanted to put a hole in a wall (for a door, for example), you would have to build the brushes around the space where you wanted the hole to be.
 
    Later editors alleviated the difficulties caused by this system and made up "smart" brushes that automatically created the gaps for holes (the editor used by the AGRIP project, QuArK, does this).
 
@@ -49,7 +49,7 @@ How would one go about making maps for *Quake* before LDL? If you just want to f
 
 The operating principle of LDL is that we start with as high-level a description as possible and gradually transform it, by filling in the details, into a low-level description suitable for compiling with the standard *Quake* map tools. This allows you to talk in terms of rooms and connections between them, whereas the map tools at the bottom of the chain want to know about scary things like intersecting 3D planes.
 
-LDL—the code—is actually a chain as mentioned above. Each stage is quite separate and the whole thing works by feeding the output of one into the next, until we have our final answer—the *.map* file.
+LDL&mdash;the code&mdash;is actually a chain as mentioned above. Each stage is quite separate and the whole thing works by feeding the output of one into the next, until we have our final answer&mdash;the *.map* file.
 
 You start by writing a pretty high-level XML file that describes your map (later we plan to add even easier ways to get data into the system, such as natural language, or an interactive editor program but for now we need to test the basic premise). An XML file is just a plain text file (think similar to HTML if you've used that before), which you can edit with any text editor (e.g. Notepad, Notepad++, ViM, …)
 
@@ -69,9 +69,9 @@ The workflow for using LDL is as follows.
 
 The test release is focused on describing the spaces and making simple deathmatch maps. It does the following.
 
-* Allows you to describe rooms—their size and style (which causes texturing and lighting to be automatically applied so that sighted people can play your maps too).
+* Allows you to describe rooms&mdash;their size and style (which causes texturing and lighting to be automatically applied so that sighted people can play your maps too).
 
-* Allows you to specify how rooms are connected (directly) to each other—i.e. you can specify that a given room is positioned north of another room and that there should be a door between them and both rooms will be positioned correctly—including at the right height—and the door—and any required stairs or an elevation platform—inserted.
+* Allows you to specify how rooms are connected (directly) to each other&mdash;i.e. you can specify that a given room is positioned north of another room and that there should be a door between them and both rooms will be positioned correctly&mdash;including at the right height&mdash;and the door&mdash;and any required stairs or an elevation platform&mdash;inserted.
 
 * Placement of items within rooms (such as player start points and weapons) on a compass directions system (this is planned to be expanded into percentage-based coordinates in the future).
 
@@ -79,27 +79,27 @@ It does have some limitations, though…
 
 * It doesn't support non-rectangular rooms (sorry, my geometry sucks; but you can still make a lot of different overall shapes of interconnected spaces, even with this limitation).
 
-* It can't make connections between rooms that are not next to each other—that is to say you need to specify the corridors that connect between rooms (as rooms themselves, which they are—they’re usually just longer and thinner).
+* It can't make connections between rooms that are not next to each other&mdash;that is to say you need to specify the corridors that connect between rooms (as rooms themselves, which they are&mdash;they’re usually just longer and thinner).
 
-* It doesn't support: rooms containing water/slime/lava; switches/buttons and doors that require keys—though all of these could be added rather easily.
+* It doesn't support: rooms containing water/slime/lava; switches/buttons and doors that require keys&mdash;though all of these could be added rather easily.
 
 ### Possible and blue sky features
 
 Here are some features that would be fairly possible given the current foundations…
 
-* Higher-level descriptions—giving you the ability to say roughly where some rooms are in 3D space and the programs working out the best way to link them (i.e. with corridors, stairs or lifts).
+* Higher-level descriptions&mdash;giving you the ability to say roughly where some rooms are in 3D space and the programs working out the best way to link them (i.e. with corridors, stairs or lifts).
 
 * Providing a natural language-like interface. Currently the description is written in a type of XML file, but it would be easy to use something similar but lighter, like JSON, and quite do-able to expand to more natural language, and to provide level-editing programs based on the format.
 
 * Providing a level editor application to make writing the descriptions and make error-checking easier.
 
-Some limitations of the system that may be addressed in future include the inability of it to cope with angled/slanted brushes. This isn't so much of a limitation at the moment as we can use stairs and so on—and are not aware of the best way to present such complex structures. Once we've done more research into how to navigate such maps and how to represent them in LDL this may be an area of improvement.
+Some limitations of the system that may be addressed in future include the inability of it to cope with angled/slanted brushes. This isn't so much of a limitation at the moment as we can use stairs and so on&mdash;and are not aware of the best way to present such complex structures. Once we've done more research into how to navigate such maps and how to represent them in LDL this may be an area of improvement.
 
-For now, however, there's a great deal you *can* do—as we hope the tutorial below will show.
+For now, however, there's a great deal you *can* do&mdash;as we hope the tutorial below will show.
 
 ### Running LDL
 
-LDL comes as part of *AudioQuake*—you can access it via the launcher's "Map" tab. There you can open a map file you're working on (or one of the tutorial examples that match the tutorial steps below) and build and play it.
+LDL comes as part of *AudioQuake*&mdash;you can access it via the launcher's "Map" tab. There you can open a map file you're working on (or one of the tutorial examples that match the tutorial steps below) and build and play it.
 
 If you clone the AGRIP code repo from GitHub, you can also use the LDL command-line tools. Info on how to do that is provided in the READMEs and in the help for the LDL program itself.
 
@@ -113,7 +113,7 @@ Before you start, please be aware of the following.
 
 * LDL maps are XML files, which are plain text files and look similar to HTML files. You can edit them with any text editor. However, as with HTML, there are rules about opening/closing tags and how to specify attributes (more on this later).
 
-   You should be able to copy and paste from this document into a text file—name it something like *tutorial.xml*—and run it through the LDL system. If you are new to XML don't worry—you can copy the examples given here.
+   You should be able to copy and paste from this document into a text file&mdash;name it something like *tutorial.xml*&mdash;and run it through the LDL system. If you are new to XML don't worry&mdash;you can copy the examples given here.
 
 * It is strongly recommended that you keep testing the map as you go along with writing it, as often as you can do so. This will help you appreciate how the system works and help you to determine when an error in your map (or bug in our code) has been introduced.
 
@@ -121,7 +121,7 @@ Before you start, please be aware of the following.
 
 * Unless you add enough deathmatch player start points, you will have great problems running the map in deathmatch mode, as all of the bots will try to spawn out of one start point. You'll read later how to add start points.
 
-   For now, be aware that the *AudioQuake* launcher and the LDL command-line tools open your maps in non-deathmatch mode. For that to work, you have to have one—and only one—`info_player_start` entity in your map. Again, more on this later.
+   For now, be aware that the *AudioQuake* launcher and the LDL command-line tools open your maps in non-deathmatch mode. For that to work, you have to have one&mdash;and only one&mdash;`info_player_start` entity in your map. Again, more on this later.
 
 ### Example 1: Hello, world!
 
@@ -147,7 +147,7 @@ This starts our map off; it's an XML *element* called "map". Elements are writte
 
 * A *style*, which is "base" in this case. This affects lighting, texturing, sounds and key types used in the map.
 
-  The style of a map is used to denote which texture, lighting and—to some extent—sound scheme is applied. Currently, LDL supports "base" and "medieval".
+  The style of a map is used to denote which texture, lighting and&mdash;to some extent&mdash;sound scheme is applied. Currently, LDL supports "base" and "medieval".
 
   When building a map, you can choose whether you want to use textures from *Quake* (if you bought and installed the data files), *Open Quartz* or a high-contrast texture set (from *Prototype.wad*). Each texture set supports both "base" and "medieval" styles.
 
@@ -219,7 +219,7 @@ If you were to specify a size that is not valid, you would get an error message.
 </map>
 ```
 
-### Example 4: Room sizes in each dimension—or: corridors!
+### Example 4: Room sizes in each dimension&mdash;or: corridors!
 
 Because the room is a 3D object, you can also specify its size in the 3 dimensions: width, depth and height. Different programs and systems use these terms differently, so to avoid any possible confusion, we'll define them as LDL uses them here.
 
@@ -227,7 +227,7 @@ Because the room is a 3D object, you can also specify its size in the 3 dimensio
 * **depth** is the distance from back to front.
 * **height** is the distance from floor to ceiling.
 
-When you only give one word for the size, LDL will work out an appropriate 3D room size based on the one given. If you want more control, though, you'll need to specify all three (note that you can’t specify just 2 of the 3 dimensions—in that case, LDL could not know which 2 of the 3 you mean).
+When you only give one word for the size, LDL will work out an appropriate 3D room size based on the one given. If you want more control, though, you'll need to specify all three (note that you can’t specify just 2 of the 3 dimensions&mdash;in that case, LDL could not know which 2 of the 3 you mean).
 
 Try making the room into a corridor: copy and paste the following into a file, then save, compile and test it.
 
@@ -241,9 +241,9 @@ Try making the room into a corridor: copy and paste the following into a file, t
 
 You will spawn in the middle of a thin, but long, corridor-shaped room. Try strafing left/right and notice you hit the walls almost immediately. Then try going back and forward.
 
-One last thing to note about room sizes in LDL is that the sizes in the width and depth dimensions have been designed to increase more quickly than in height—that is to say that a room with the size "med" (which is the same as "med med med") will be wider and deeper than it is tall. It will be as wide as it is deep but it won't be quite as high. This is because in most *Quake* maps, as with most buildings, rooms are not completely cube-shaped. This feature is designed to make it easy for you to make realistically-sized rooms even when you only specify one word for the size attribute.
+One last thing to note about room sizes in LDL is that the sizes in the width and depth dimensions have been designed to increase more quickly than in height&mdash;that is to say that a room with the size "med" (which is the same as "med med med") will be wider and deeper than it is tall. It will be as wide as it is deep but it won't be quite as high. This is because in most *Quake* maps, as with most buildings, rooms are not completely cube-shaped. This feature is designed to make it easy for you to make realistically-sized rooms even when you only specify one word for the size attribute.
 
-If you really really want to make your room exactly cube-shaped, you can—use any of the following for your room's size attribute "vsmall vsmall small", "small small big", "med med vlarge", "big big xlarge", "large large huge", "xlarge xlarge vhuge" or "huge huge xhuge".
+If you really really want to make your room exactly cube-shaped, you can&mdash;use any of the following for your room's size attribute "vsmall vsmall small", "small small big", "med med vlarge", "big big xlarge", "large large huge", "xlarge xlarge vhuge" or "huge huge xhuge".
 
 #### XML errors
 
@@ -287,7 +287,7 @@ Now to make the map a bit more interesting! We will create two rooms and link th
 
 There are now 2 rooms, "start" and "other", which are linked by a door. LDL places the room "other" to the north of "start" because we asked the connection to "other" to be made via the north wall ("n") of "start". The north wall is the one you face when spawning in the map for the first time; west and east correspond to left and right respectively and south is behind you.
 
-This is the same as the way directions work in most Interactive Fiction games. If it helps, you could imagine being above the map and looking down on it as if it was an, erm, map. Then, north would be to the top, south to the bottom, west to the left and east to the right. (Both ways of imagining the situation are the same—hopefully at least one will be helpful.)
+This is the same as the way directions work in most Interactive Fiction games. If it helps, you could imagine being above the map and looking down on it as if it was an, erm, map. Then, north would be to the top, south to the bottom, west to the left and east to the right. (Both ways of imagining the situation are the same&mdash;hopefully at least one will be helpful.)
 
 ### Example 6: Connecting rooms the other way around
 
@@ -304,7 +304,7 @@ Above we specified the connection inside the room "start". It works the other wa
 </map>
 ```
 
-Run the map through LDL and experiment. The room you start in will lead onto another room, which you will access via a door that is directly in front of you when you start (LDL places doors in the middle of the wall they're on and at ground level by default—more on this later).
+Run the map through LDL and experiment. The room you start in will lead onto another room, which you will access via a door that is directly in front of you when you start (LDL places doors in the middle of the wall they're on and at ground level by default&mdash;more on this later).
 
 ### Example 7: Items and monsters
 
@@ -460,11 +460,11 @@ To make things a bit more exciting, however, you might want to make some rooms h
 
 This is very similar to the example above (*tut05*), however, we have added two attributes to the connection from the room "start" to the room "other". These are:
 
-* **pos** This is the position *on the connecting wall* that you want the hole/door to be created. That is to say: when you specify a position—"top" (t) in this case—you are specifying the position on that wall where you want the hole to be made, as if you were standing in front of the wall itself.
+* **pos** This is the position *on the connecting wall* that you want the hole/door to be created. That is to say: when you specify a position&mdash;"top" (t) in this case&mdash;you are specifying the position on that wall where you want the hole to be made, as if you were standing in front of the wall itself.
 
-   Valid positions are: "tl" (top left), "t" (top centre), "tr" (top right), "r" (right), "br" (bottom right), "b" (bottom centre—which is the default), "bl" (bottom left) and "c" (centre).
+   Valid positions are: "tl" (top left), "t" (top centre), "tr" (top right), "r" (right), "br" (bottom right), "b" (bottom centre&mdash;which is the default), "bl" (bottom left) and "c" (centre).
 
-* **elevtype** When you specify that the connecting hole/door is to be placed somewhere other than at ground level on the wall, it might be necessary to provide some means for the player to access the hole—i.e. stairs or a "plat" (lifting platform). You will be warned when this may be necessary, but as it's a design decision and you may not wish the player to be granted access through this route, you can specify "none" to disable the creation of such a device.
+* **elevtype** When you specify that the connecting hole/door is to be placed somewhere other than at ground level on the wall, it might be necessary to provide some means for the player to access the hole&mdash;i.e. stairs or a "plat" (lifting platform). You will be warned when this may be necessary, but as it's a design decision and you may not wish the player to be granted access through this route, you can specify "none" to disable the creation of such a device.
 
 Have a go running this map: walk straight forward and you will find some stairs. Carry on and you'll go up into the second room.
 
@@ -474,7 +474,7 @@ Try changing the value of the `elevtype` attribute for the connection to "plat" 
 
 Try changing the `pos` to "tl" from "t" and you'll find that you have to move to the left/west to find the stairs up to room "other".
 
-It is important to note that even when you use the `pos` attribute to change the position on the wall in the "start" room, you still always end up in "other" at the same place—the connection on that side is made in the default place of the middle of the connecting wall, at ground level.
+It is important to note that even when you use the `pos` attribute to change the position on the wall in the "start" room, you still always end up in "other" at the same place&mdash;the connection on that side is made in the default place of the middle of the connecting wall, at ground level.
 
 Once you're happy with this, you might be asking how you can reposition the connector on the target room’s side. Let’s take the example above and change it so that both rooms are actually at the same height but the door between them is at the top of the wall. Stairs will be built to get up to and down from the door on both sides.
 
@@ -494,7 +494,7 @@ Once you're happy with this, you might be asking how you can reposition the conn
 
 Say you have two rooms, at different heights and you want to make a connection between them, in the form of a corridor with stairs in it. This is an example of how you might go about doing so.
 
-We have two rooms—"start" and "other" as ever. We will position "other" to the north of "start", also as ever. This time, though, we will place a corridor between the two. The corridor will be not very wide, quite long and quite tall so that it can accommodate the change in height from "start" to "other".
+We have two rooms&mdash;"start" and "other" as ever. We will position "other" to the north of "start", also as ever. This time, though, we will place a corridor between the two. The corridor will be not very wide, quite long and quite tall so that it can accommodate the change in height from "start" to "other".
 
 As the corridor will be connecting "start" and "other" we'll give it the ID "start2other". This quickly identifies it as a corridor. Here is the map…
 
@@ -515,13 +515,13 @@ As the corridor will be connecting "start" and "other" we'll give it the ID "sta
 
 When you enter this map, you'll find a door in front of you and then a corridor, which has a set of steps at the end that lead (without a door) into a room with the rocket launcher.
 
-But those steps are very steep and—as you're using the entirety of "start2other" as a corridor—it would be much better if those steps filled the whole room rather than just a small part of it. You can make this happen, as follows…
+But those steps are very steep and&mdash;as you're using the entirety of "start2other" as a corridor&mdash;it would be much better if those steps filled the whole room rather than just a small part of it. You can make this happen, as follows…
 
 ```xml
 <con wall='n' target='other' pos='t' elevtype='stairs' extent='+' />
 ```
 
-We've added an attribute, `extent`, to the connection and given it the size "+". That should be read as "fill all available space". Try making this change and running the map—the stairs will take up all of the available space in the corridor but not above the height they’re meant to be).
+We've added an attribute, `extent`, to the connection and given it the size "+". That should be read as "fill all available space". Try making this change and running the map&mdash;the stairs will take up all of the available space in the corridor but not above the height they’re meant to be).
 
 You can specify sizes ("small", "med" and so on) in the `extent` attribute, as you can with rooms. You can also mix and match, so saying `extent='+ med'` means "take up all available width, but be only medium-sized in depth". Bear in mind that if the corridor was going from east to west (or vice-verse) these would be reversed (which is why it's often easier to just use "+" as the size specifier).
 
@@ -545,7 +545,7 @@ Another thing that could be done in future is supporting teleporters, so you cou
 
 * Items are placed in rooms according to the same compass direction scheme.
 
-* When assigning sizes to things like rooms, we may say "large" or, if we want to be more precise, specify the size in each of the 3 dimensions of width, depth and height, separated by spaces—e.g. "medium large medium". When facing north in a room, its width is the distance from your left to your right; its depth is the distance from back to front and its height is vertical distance between its floor and ceiling.
+* When assigning sizes to things like rooms, we may say "large" or, if we want to be more precise, specify the size in each of the 3 dimensions of width, depth and height, separated by spaces&mdash;e.g. "medium large medium". When facing north in a room, its width is the distance from your left to your right; its depth is the distance from back to front and its height is vertical distance between its floor and ceiling.
 
 ## Tricks and treats
 
@@ -561,7 +561,7 @@ The file "style.xml" included with LDL contains information on the textures and 
 
 As well as the "base" and "medieval" styles described above, you can define other texture set styles to use in different rooms (but not the map as a whole). There are already two in the "style.xml" file: "outsidelight" and "outsidedark". When applied to a room, they change the walls and ceiling to a sky texture, and the floor to a ground/grass texture.
 
-These other styles can be applied to a room, but not the map itself. They don't have to define replacements for all of the textures defined by a set—if any are missing, LDL will fall back to the underlying map style ("base" or "medieval").
+These other styles can be applied to a room, but not the map itself. They don't have to define replacements for all of the textures defined by a set&mdash;if any are missing, LDL will fall back to the underlying map style ("base" or "medieval").
 
 You can define your own by editing "style.xml".
 
@@ -577,7 +577,7 @@ Whilst LDL doesn't allow for very advanced geometry, and it doesn't stop you fro
 
 The tutorial files ("tut\*.xml" as covered above) are provided for your reference and are available from the *AudioQuake* launcher. You'll also find various example maps there too.
 
-If you check out the code from the repository, you will find the test maps there too. They're named like "test_0\*_\*.xml"). The number in the name indicates which layer of the system the map is written for (remember earlier we discussed that LDL is composed of a number of layers). The layer "05" maps are the ones you want—lower levels rely on absolute coordinates.
+If you check out the code from the repository, you will find the test maps there too. They're named like "test_0\*_\*.xml"). The number in the name indicates which layer of the system the map is written for (remember earlier we discussed that LDL is composed of a number of layers). The layer "05" maps are the ones you want&mdash;lower levels rely on absolute coordinates.
 
 <!-- FIXME: is that true re absolutes? -->
 


### PR DESCRIPTION
For some reason, the unicode chars were not translating properly when the manuals were converted on Windows. This replaces them with HTML entities (or, in the case of the "thin spaces", normal spaces).

I could've tried moving to mistune 2.0-rc but decided this was the minimum-effective-dose solution.