### PR TITLE
feat: About window; Documentation cleanups; Window sizing

### DIFF
--- a/audioquake/AudioQuake.py
+++ b/audioquake/AudioQuake.py
@@ -7,6 +7,7 @@ import launcherlib.config as config
 import launcherlib.dirs as dirs
 from launcherlib.game_controller import GameController
 from launcherlib.utils import error_message_and_title, format_bindings_as_text
+from launcherlib.ui.helpers import about_page
 
 
 #
@@ -24,6 +25,8 @@ def gui_main(game_controller, args):
 	game_controller.set_error_handler(gui_error_hook)
 
 	try:
+		if config.first_game_run():
+			about_page(None)
 		LauncherWindow(
 			None, "AudioQuake & LDL Launcher", game_controller).Show()
 		app.MainLoop()

--- a/audioquake/AudioQuake.spec
+++ b/audioquake/AudioQuake.spec
@@ -10,7 +10,8 @@ data_files = [
 	('../ldl/style.xml', 'maptools'),
 	('../giants/prototype_wad_1_2/prototype_1_2.wad', 'maptools'),
 	('../giants/oq-pak-src-2004.08.01/maps/textures/free_wad.wad', 'maptools'),
-	('bindings-template.html', '.')]
+	('bindings-template.html', '.'),
+	('about.html', '.')]
 
 binary_files = doset(
 	mac=[

--- a/audioquake/CHANGELOG.md
+++ b/audioquake/CHANGELOG.md
@@ -1,4 +1,4 @@
-# AudioQuake 2021.0 (03/04/2021)
+# AudioQuake & Level Description Language 2021.0 (03/04/2021)
 
 This is a re-release in which we've massively revamped the
 code---including the Level Description Language (LDL)---to run on modern
@@ -24,7 +24,7 @@ that you could more easily make levels for it.
 
 -   More flexible styling of LDL maps (supporting the above sets of
     textures, as well as additional styles you can apply to parts of
-    maps, e.g. to make some areas appear outside).
+    maps, e.g. to make some areas appear outside).
 
 -   Big documentation updates.
 

--- a/audioquake/CHANGELOG.md
+++ b/audioquake/CHANGELOG.md
@@ -1,5 +1,4 @@
-AudioQuake 2020.0 (Latest beta: ??/??/2020)
-===========================================
+# AudioQuake 2021.0 (03/04/2021)
 
 This is a re-release in which we've massively revamped the
 code---including the Level Description Language (LDL)---to run on modern
@@ -11,26 +10,36 @@ that you could more easily make levels for it.
 
 -   Level Description Language (LDL) tools and tutorials are included
     with the game.
--   Shiny new GUI launcher (based on wxWidgets), with all the main
-    features of the previous text-based launcher (including QMOD and
-    registered Quake data installation) and more.
+
+-   Shiny new GUI launcher (based on wxWidgets and wxPython), with all
+    the main features of the previous text-based launcher (including
+    QMOD and registered Quake data installation) and more.
+
 -   You can play out-of-the-box courtesy of the Open Quartz community
     data pack.
+
 -   Levels you make can be played using Quake or Open Quartz textures,
-    or a new set of high-contrast textures.
+    or a new set of high-contrast textures (inspired by *The Last of Us
+    Part II*).
+
 -   More flexible styling of LDL maps (supporting the above sets of
     textures, as well as additional styles you can apply to parts of
-    maps, e.g. to make some areas appear outside).
--   The launcher can load in the registered Quake data if you bought the
-    game.
+    maps, e.g. to make some areas appear outside).
+
 -   Big documentation updates.
+
 -   Much code clean-up behind the scenes.
+
     -   All of the Python code has been tidied up a lot.
+
     -   We are now using PyInstaller to bundle the app.
+
     -   Slicker text-to-speech performance.
 
-AudioQuake 0.3.0 (02/01/2008)
-=============================
+The Stats and Servers site is no longer available, but you can still run
+your own servers if you have the registered version of Quake.
+
+# AudioQuake 0.3.0 (02/01/2008)
 
 This is the first release of AudioQuake; a game based on AccessibleQuake
 that aims to take accessibility and community involvement to its logical
@@ -40,22 +49,30 @@ of hard work. So much has changed that only a summary is given here.
 -   Move to the ZQuake QuakeWorld engine---the first Open Source
     mainstream accessible game engine (many thanks to Tonik and the
     other developers for allowing our patches in).
+
 -   Port of the AccessibleQuake game code to ZQuake's QuakeC system
     (which supports multiple online and offline gametypes).
+
 -   Internet Multiplayer support---Yes; you can play Quake online a
     variety of game modes!
+
 -   Internet Game Server---Set up your own games with total control over
     maps and game rules.
+
 -   Online statistics---track your progress with respect to other
     AudioQuake players.
+
 -   http://stats.agrip.org.uk/ is a portal for all online features of
     the game.
+
 -   Manual re-written to take into account new features and be even more
     helpful :-).
+
 -   Ease of setup increased due to more support programs being included
     and the ability to install from a Registered Quake CD on Windows and
     Linux, as well as being able to use the data from the downloadable
     version of Quake for Windows.
+
 -   Many bug fixes and feature enhancements to both the engine and game
     code in this move---such as new footstep sounds (from Davy Loots)
     and movement speed indication, ESR enhancements and general gameplay
@@ -67,8 +84,7 @@ game types (such as Capture The Flag). Major new features (such as
 ImplicitAccessibility and LevML support) shall be added in future
 release series.
 
-AccessibleQuake 0.2.1 (29/07/2004)
-==================================
+# AccessibleQuake 0.2.1 (29/07/2004)
 
 Changed the name of this "product" to AccessibleQuake (from "AGRIP") to
 differentiate it from the name of the organisation and of the other
@@ -108,8 +124,7 @@ project we now host ("AudioQuake").
 
 -   Open space detection works underwater.
 
-AGRIP 0.2.0 (06/07/2004)
-========================
+# AGRIP 0.2.0 (06/07/2004)
 
 In development this was 0.1.1 but the decision to release as 0.2.0 was
 made because there have been a number of big improvements.
@@ -176,8 +191,7 @@ made because there have been a number of big improvements.
     Unfortunately we still have not been able to find any footstep
     sounds after a great deal of searching.
 
-AGRIP 0.1.0 (11/06/2004)
-========================
+# AGRIP 0.1.0 (11/06/2004)
 
 Whilst in development, this was 0.0.5, but was re-released as 0.1.0
 (beta) due to the new sounds going in.
@@ -205,8 +219,7 @@ Whilst in development, this was 0.0.5, but was re-released as 0.1.0
 
 -   Sebby's sounds are now in! These include ESR, D5k and toggle sounds.
 
-AGRIP 0.0.4 (22/05/2004)
-========================
+# AGRIP 0.0.4 (22/05/2004)
 
 -   Added jump detection---you can press J for a description of ho you
     will be able to make a jump. If the hazard doesn't represent a jump,
@@ -275,8 +288,7 @@ AGRIP 0.0.4 (22/05/2004)
 
 -   Included Sebby's on/off toggle sounds for various items.
 
-AGRIP 0.0.3 (13/05/2004)
-========================
+# AGRIP 0.0.3 (13/05/2004)
 
 First release after 0.0.x has been extended.
 
@@ -332,8 +344,7 @@ First release after 0.0.x has been extended.
     disable this sound so that no sound whatsoever is made when an
     object is outside your FOV.
 
-AGRIP 0.0.2 (15/04/2004)
-========================
+# AGRIP 0.0.2 (15/04/2004)
 
 Same as 0.0.1 but with the following fixes:
 
@@ -348,8 +359,7 @@ Same as 0.0.1 but with the following fixes:
     wall half of the volume of the other wall-hit sounds (so you know
     that the wall is behind, not in front, of you).
 
-AGRIP 0.0.1 (14/04/2004)
-========================
+# AGRIP 0.0.1 (14/04/2004)
 
 The first alpha release. This is also the first release to support
 Windows.
@@ -379,7 +389,6 @@ Windows.
 -   A compass has been added and works quite well (a few minor tweaks
     are on their way).
 
-AGRIP 0.0.0 (14/03/2004)
-========================
+# AGRIP 0.0.0 (14/03/2004)
 
 Initial pre-alpha release.

--- a/audioquake/about.html
+++ b/audioquake/about.html
@@ -20,7 +20,7 @@ h1 { margin-top: 0; }
 		<h1>AudioQuake &amp; Level Description Language</h1>
 		<p><strong>$version</strong></p>
 
-		<p>This is a re-release, with a new launcher and tools, that runs on contemporary macOS and Windows versions. What can you do with it?</p>
+		<p>This is a re-release of the 2008 game, with a new launcher, updated mapping tools, and a few other updates and tweaks. What can you do with it?</p>
 
 		<p>You can <strong>play</strong> the game. <em>Open Quartz</em> is available out-of-the-box. If you have the registered version of <em>Quake</em>, which is recommended, you can install its data via the launcher. Note that accessibility of the levels is variable!</p>
 

--- a/audioquake/about.html
+++ b/audioquake/about.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8">
+		<title>About AudioQuake & Level Description Language</title>
+		<link rel="stylesheet" href="$path">
+		<style>
+body {
+	margin-bottom: 1em;
+	text-align: center;
+	hyphens: none;
+	-webkit-hyphens: none;
+	-moz-hyphens: none;
+	-ms-hyphens: none;
+}
+h1 { margin-top: 0; }
+		</style>
+	</head>
+	<body>
+		<h1>AudioQuake &amp; Level Description Language</h1>
+		<p><strong>$version</strong></p>
+
+		<p>This is a re-release, with a new launcher and tools, that runs on contemporary macOS and Windows versions. What can you do with it?</p>
+
+		<p>You can <strong>play</strong> the game. <em>Open Quartz</em> is available out-of-the-box. If you have the registered version of <em>Quake</em>, which is recommended, you can install its data via the launcher. Note that accessibility of the levels is variable!</p>
+
+		<p>Try the accessible <strong>mapping</strong> tools a.k.a. the Level Description Language. The geometry is basic, but it lets you describe your own 3D spaces and then creates the playable maps for you, with your choice of texture and lighting styles.</p>
+
+		<p>You can also play <strong>mods</strong> for the game, and make your own.</p>
+
+		<p>Detailed info on all of the above is available from within the launcher&mdash;<strong>please read the docs :-)</strong>.</p>
+	</body>
+</html>

--- a/audioquake/bindings-template.html
+++ b/audioquake/bindings-template.html
@@ -5,8 +5,8 @@
 		<title>Key bindings</title>
 		<link rel="stylesheet" href="$path">
 		<style>
-h1 { margin-top: 0; }
 body { margin-bottom: 1em; }
+h1 { margin-top: 0; }
 		</style>
 	</head>
 	<body>

--- a/audioquake/build-audioquake.py
+++ b/audioquake/build-audioquake.py
@@ -225,7 +225,7 @@ def convert_manuals():
 		'AudioQuake sound legend': [
 			Build.dir_manuals_src / 'user-manual-part07-b.md', 'sound-legend'],
 		'Level Description Language tutorial': [
-			Build.dir_ldl / 'tutorial.md', 'ldl-tutorial']
+			Build.dir_ldl / 'tutorial.md', 'LDL-tutorial']
 	}
 
 	for title, details in single_docs_to_convert.items():

--- a/audioquake/build-audioquake.py
+++ b/audioquake/build-audioquake.py
@@ -20,6 +20,7 @@ from buildlib import Build, \
 from ldllib.build import build, swap_wad, bsp_maybe_hc
 from ldllib.utils import use_repo_wads, have_wad, WADs, \
 	have_needed_tools, use_repo_bins
+from release import version_string, release_name
 
 
 #
@@ -96,7 +97,6 @@ if next(Build.dir_maps_quakewad.glob('*.bsp'), None) is not None:
 # Constants and state
 #
 
-version_string = None     # read from 'release' file
 skip_pyinstaller = False  # set via command-line option
 force_map_build = False   # also set via CLI
 needed_quake_wad = False  # detected via build_maps_for_quake()
@@ -339,14 +339,9 @@ def make_zip():
 #
 
 def build_audioquake():
-	global version_string
-
-	with open(Build.file_aq_release, 'r') as f:
-		version_string = f.readline().rstrip()
-		version_name = f.readline().rstrip()
-		print(
-			'Building AudioQuake & Level Description Language',
-			version_string + ': ' + version_name)
+	print(
+		'Building AudioQuake & Level Description Language',
+		version_string + ': ' + release_name)
 
 	check_platform()
 

--- a/audioquake/build-audioquake.py
+++ b/audioquake/build-audioquake.py
@@ -219,14 +219,13 @@ def convert_manuals():
 	single_docs_to_convert = {
 		'README': [Build.dir_readme_licence / 'README.md', 'README'],
 		'LICENCE': [Build.dir_readme_licence / 'LICENCE.md', 'LICENCE'],
+		'CHANGELOG': [Build.dir_aq / 'CHANGELOG.md', 'CHANGELOG'],
+		'ACKNOWLEDGEMENTS': [
+			Build.dir_aq / 'ACKNOWLEDGEMENTS.md', 'ACKNOWLEDGEMENTS'],
 		'AudioQuake sound legend': [
-			Build.dir_manuals_src / 'user-manual-part07-b.md',
-			'sound-legend'
-		],
+			Build.dir_manuals_src / 'user-manual-part07-b.md', 'sound-legend'],
 		'Level Description Language tutorial': [
-			Build.dir_ldl / 'tutorial.md',
-			'ldl-tutorial'
-		]
+			Build.dir_ldl / 'tutorial.md', 'ldl-tutorial']
 	}
 
 	for title, details in single_docs_to_convert.items():

--- a/audioquake/launcherlib/ui/helpers.py
+++ b/audioquake/launcherlib/ui/helpers.py
@@ -32,7 +32,9 @@ class _HTMLPageDialog(wx.Dialog):
 
 		wx.Dialog.__init__(
 			self, parent, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
-			size=(screen_width * 0.6, screen_height * 0.75),
+			size=(
+				min(screen_width * 0.6, 1000),
+				min(screen_height * 0.75, 703)),
 			title=title)
 		sizer = wx.BoxSizer(wx.VERTICAL)
 

--- a/audioquake/launcherlib/ui/launcher.py
+++ b/audioquake/launcherlib/ui/launcher.py
@@ -13,7 +13,8 @@ from launcherlib.ui.tabs.map import MapTab
 
 class LauncherWindow(wx.Frame):
 	def __init__(self, parent, title, game_controller):
-		wx.Frame.__init__(self, parent, title=title)
+		flags = wx.DEFAULT_FRAME_STYLE & ~(wx.RESIZE_BORDER | wx.MAXIMIZE_BOX)
+		wx.Frame.__init__(self, parent, title=title, style=flags)
 
 		sizer = wx.BoxSizer(wx.VERTICAL)
 

--- a/audioquake/launcherlib/ui/tabs/help.py
+++ b/audioquake/launcherlib/ui/tabs/help.py
@@ -17,16 +17,18 @@ class HelpTab(wx.Panel):
 
 		add_widget(sizer, wx.StaticLine(self, -1))
 
+		about = wx.Button(self, -1, 'About')
+		about.Bind(wx.EVT_BUTTON, lambda event: about_page(self))
+		add_widget(sizer, about)
+
+		add_widget(sizer, wx.StaticLine(self, -1))
+
 		add_opener_buttons(self, sizer, {
 			'README': dirs.manuals / 'README.html',
 			'LICENCE': dirs.manuals / 'LICENCE.html',
 			'CHANGELOG': dirs.manuals / 'CHANGELOG.html',
 			'ACKNOWLEDGEMENTS': dirs.manuals / 'ACKNOWLEDGEMENTS.html'
 		})
-
-		about = wx.Button(self, -1, 'About')
-		about.Bind(wx.EVT_BUTTON, lambda event: about_page(self))
-		add_widget(sizer, about)
 
 		sizer.SetSizeHints(self)
 		self.SetSizer(sizer)

--- a/audioquake/launcherlib/ui/tabs/help.py
+++ b/audioquake/launcherlib/ui/tabs/help.py
@@ -11,9 +11,14 @@ class HelpTab(wx.Panel):
 		sizer = wx.BoxSizer(wx.VERTICAL)
 
 		add_opener_buttons(self, sizer, {
-			'README': dirs.manuals / 'README.html',
 			'User manual': dirs.manuals / 'user-manual.html',
 			'Sound legend': dirs.manuals / 'sound-legend.html',
+		})
+
+		add_widget(sizer, wx.StaticLine(self, -1))
+
+		add_opener_buttons(self, sizer, {
+			'README': dirs.manuals / 'README.html',
 			'LICENCE': dirs.manuals / 'LICENCE.html',
 			'CHANGELOG': dirs.manuals / 'CHANGELOG.html',
 			'ACKNOWLEDGEMENTS': dirs.manuals / 'ACKNOWLEDGEMENTS.html'

--- a/audioquake/launcherlib/ui/tabs/help.py
+++ b/audioquake/launcherlib/ui/tabs/help.py
@@ -2,7 +2,7 @@
 import wx
 
 from launcherlib import dirs
-from launcherlib.ui.helpers import add_opener_buttons
+from launcherlib.ui.helpers import add_opener_buttons, about_page, add_widget
 
 
 class HelpTab(wx.Panel):
@@ -16,6 +16,10 @@ class HelpTab(wx.Panel):
 			'Sound legend': dirs.manuals / 'sound-legend.html',
 			'LICENCE': dirs.manuals / 'LICENCE.html'
 		})
+
+		about = wx.Button(self, -1, 'About')
+		about.Bind(wx.EVT_BUTTON, lambda event: about_page(self))
+		add_widget(sizer, about)
 
 		sizer.SetSizeHints(self)
 		self.SetSizer(sizer)

--- a/audioquake/launcherlib/ui/tabs/help.py
+++ b/audioquake/launcherlib/ui/tabs/help.py
@@ -14,7 +14,9 @@ class HelpTab(wx.Panel):
 			'README': dirs.manuals / 'README.html',
 			'User manual': dirs.manuals / 'user-manual.html',
 			'Sound legend': dirs.manuals / 'sound-legend.html',
-			'LICENCE': dirs.manuals / 'LICENCE.html'
+			'LICENCE': dirs.manuals / 'LICENCE.html',
+			'CHANGELOG': dirs.manuals / 'CHANGELOG.html',
+			'ACKNOWLEDGEMENTS': dirs.manuals / 'ACKNOWLEDGEMENTS.html'
 		})
 
 		about = wx.Button(self, -1, 'About')

--- a/audioquake/launcherlib/ui/tabs/map.py
+++ b/audioquake/launcherlib/ui/tabs/map.py
@@ -54,7 +54,7 @@ class MapTab(wx.Panel):
 
 		add_opener_button(
 			self, sizer, 'Read the LDL tutorial',
-			dirs.manuals / 'ldl-tutorial.html')
+			dirs.manuals / 'LDL-tutorial.html')
 
 		# File picker and choosing a tutorial or example map bits
 

--- a/audioquake/launcherlib/ui/tabs/play.py
+++ b/audioquake/launcherlib/ui/tabs/play.py
@@ -7,11 +7,11 @@ except ImportError:
 import wx
 import wx.html2
 
-from buildlib import doset, doset_only
+from buildlib import doset
 from launcherlib import dirs
 from launcherlib.utils import have_registered_data, format_bindings_as_html
 from launcherlib.ui.helpers import add_widget, launch_core, \
-	Error, HOW_TO_INSTALL
+	Error, HOW_TO_INSTALL, modal_html_page
 
 
 #
@@ -81,42 +81,9 @@ def add_cli_tool_button(parent, sizer, title, action):
 	add_widget(sizer, button)
 
 
-def windows_accessibility_fix(browser):
-	robot = wx.UIActionSimulator()
-	browser.SetFocus()
-	position = browser.GetPosition()
-	position = browser.ClientToScreen(position)
-	robot.MouseMove(position)
-	robot.MouseClick()
-
-
 #
 # The main event
 #
-
-class KeyBindingsView(wx.Dialog):
-	def __init__(self, parent):
-		screen_width, screen_height = wx.GetDisplaySize()
-
-		wx.Dialog.__init__(
-			self, parent, style=wx.DEFAULT_DIALOG_STYLE | wx.RESIZE_BORDER,
-			size=(screen_width * 0.5, screen_height * 0.7),
-			title='Key bindings')
-		sizer = wx.BoxSizer(wx.VERTICAL)
-
-		browser = wx.html2.WebView.New(self)
-		display = format_bindings_as_html()
-		browser.SetPage(display, "")
-		sizer.Add(browser, 1, wx.EXPAND, 10)
-
-		close = wx.Button(self, -1, 'Close')
-		close.Bind(wx.EVT_BUTTON, lambda event: self.Destroy())
-		add_widget(sizer, close)
-
-		self.SetSizer(sizer)
-
-		doset_only(windows=lambda: windows_accessibility_fix(browser))
-
 
 class PlayTab(wx.Panel):
 	def __init__(self, parent, game_controller):
@@ -141,13 +108,14 @@ class PlayTab(wx.Panel):
 
 		add_widget(sizer, wx.StaticLine(self, -1))
 
-		bindings = wx.Button(self, -1, 'List key bindings')
+		keys_button = wx.Button(self, -1, 'List key bindings')
 
-		def bindings_window(event):
-			KeyBindingsView(self).Show()
+		def show_bindings(event):
+			bindings_html = format_bindings_as_html()
+			modal_html_page(self, 'Key bindings', bindings_html)
 
-		bindings.Bind(wx.EVT_BUTTON, bindings_window)
-		add_widget(sizer, bindings)
+		keys_button.Bind(wx.EVT_BUTTON, show_bindings)
+		add_widget(sizer, keys_button)
 
 		# Server stuff
 

--- a/audioquake/launcherlib/utils.py
+++ b/audioquake/launcherlib/utils.py
@@ -101,6 +101,11 @@ def get_bindings():
 
 	config_keys = list(config_keys_directions.values()) + config_keys_other
 
+	# Improve legibility
+	for record in autoexec_keys:
+		for field in ['current', 'default']:
+			record[field] = record[field].upper()
+
 	return config_keys, autoexec_keys
 
 
@@ -128,9 +133,14 @@ def format_bindings_as_html():
 			f"<tr><td>{key['current']}</td><td>{key['help']}</td>"
 			f"<td>{key['default']}</td></tr>\n")
 
-	with open(dirs.gubbins / 'bindings-template.html', 'r') as f:
+	return html_template(
+		dirs.gubbins / 'bindings-template.html',
+		basic=cfg,
+		advanced=autoexec)
+
+
+def html_template(file_path, **kwargs):
+	with open(file_path, 'r') as f:
 		html = Template(f.read())
 		return html.substitute(
-			path=str(dirs.manuals / 'agrip.css'),
-			basic=cfg,
-			advanced=autoexec)
+			path=str(dirs.manuals / 'agrip.css'), **kwargs)

--- a/audioquake/manuals/development-manual-part01.md
+++ b/audioquake/manuals/development-manual-part01.md
@@ -1,4 +1,4 @@
-Copyright (c)  2005-2020  Matthew Tylee Atkinson
+Copyright (c)  2005-2021  Matthew Tylee Atkinson
 
 Copyright (c)  2007  Sabahattin Gucukoglu
 

--- a/audioquake/manuals/user-manual-part01.md
+++ b/audioquake/manuals/user-manual-part01.md
@@ -1,4 +1,4 @@
-Copyright (c)  2004-2020  Matthew Tylee Atkinson
+Copyright (c)  2004-2021  Matthew Tylee Atkinson
 
 Permission is granted to copy, distribute and/or modify this document under the terms of the GNU Free Documentation License, Version 1.2 or any later version published by the Free Software Foundation; with no Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.  A copy of the license is included in the section entitled "GNU Free Documentation License".
 

--- a/audioquake/manuals/user-manual-part04.md
+++ b/audioquake/manuals/user-manual-part04.md
@@ -3,7 +3,7 @@
 
 <!-- FIXME -->
 
-**WARNING: This section has not yet been updated for the 2020 re-release.**
+**WARNING: This section has not yet been updated for the 2021 re-release.**
 
 Quake is not just a singleplayer fragfest\! In fact, many would say that it is far more fun to play over the Internet both with and against other humans. This part explains the variety of game modes on offer and how you can join in the fun.
 

--- a/audioquake/release
+++ b/audioquake/release
@@ -1,2 +1,0 @@
-2021.0-beta3
-Respawn (Digital Archaeology Edition)

--- a/audioquake/release.py
+++ b/audioquake/release.py
@@ -1,0 +1,2 @@
+version_string = '2021.0-beta3'
+release_name = 'Respawn (Digital Archaeology Edition)'

--- a/audioquake/release.py
+++ b/audioquake/release.py
@@ -1,2 +1,2 @@
-version_string = '2021.0-beta3'
+version_string = '2021.0-rc1'
 release_name = 'Respawn (Digital Archaeology Edition)'

--- a/ldl/tutorial.md
+++ b/ldl/tutorial.md
@@ -2,7 +2,7 @@
 
 The AGRIP *Level Description Language*, or LDL, is a text-based format that allows people to easily describe 3D spaces. LDL is currently aimed at blind gamers who want to make maps for *Quake*. This is a preliminary concept release, so it's important to say what it does, doesn't and might do.
 
-### Digital archaeology note from 2020
+### Digital archaeology note from 2021
 
 OK, whilst *Quake* is now ancient (but still a milestone in gaming), the techniques here could be applied to newer engines in much the same way; would love to see, or even help, that happen. In the meantime, you can still use this to make and explore your own somewhat-simplistically-shaped-but-nonetheless-3D worlds! :-)
 

--- a/lib/ldllib/ldllib/level_00_down_map2mapxml.py
+++ b/lib/ldllib/ldllib/level_00_down_map2mapxml.py
@@ -2,7 +2,7 @@
 """
 	level_00_down_map2mapxml.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MapXML file on stdin and prints a MAP file to stdout.

--- a/lib/ldllib/ldllib/level_00_up_map2mapxml.py
+++ b/lib/ldllib/ldllib/level_00_up_map2mapxml.py
@@ -2,7 +2,7 @@
 """
 	level_00_up_map2mapxml.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MAP file on stdin and prints a MapXML file to stdout.

--- a/lib/ldllib/ldllib/level_01_down_brushsizes.py
+++ b/lib/ldllib/ldllib/level_01_down_brushsizes.py
@@ -2,7 +2,7 @@
 """
 	level_01_down_brushsizes.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MapXML file on stdin with simplified brush

--- a/lib/ldllib/ldllib/level_01_up_brushsizes.py
+++ b/lib/ldllib/ldllib/level_01_up_brushsizes.py
@@ -2,7 +2,7 @@
 """
 	level_01_up_brushsizes.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This program reads a MapXML file on stdin and simplifies the brush

--- a/lib/ldllib/ldllib/level_02_down_rooms.py
+++ b/lib/ldllib/ldllib/level_02_down_rooms.py
@@ -2,7 +2,7 @@
 """
 	level_02_down_rooms.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This stage takes a room definition and turns it into brushes.

--- a/lib/ldllib/ldllib/level_03_down_lighting.py
+++ b/lib/ldllib/ldllib/level_03_down_lighting.py
@@ -2,7 +2,7 @@
 """
 	level_03_down_lighting.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 """
 

--- a/lib/ldllib/ldllib/level_04_down_buildermacros.py
+++ b/lib/ldllib/ldllib/level_04_down_buildermacros.py
@@ -2,7 +2,7 @@
 """
 	level_04_down_buildermacros.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 """
 

--- a/lib/ldllib/ldllib/level_05_down_connections.py
+++ b/lib/ldllib/ldllib/level_05_down_connections.py
@@ -2,7 +2,7 @@
 """
 	level_05_down_connections.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 """
 

--- a/lib/ldllib/ldllib/utils.py
+++ b/lib/ldllib/ldllib/utils.py
@@ -1,7 +1,7 @@
 """
 	utils.py
 	Part of the Level Description Language (LDL) from the AGRIP project.
-	Copyright 2005-2020 Matthew Tylee Atkinson
+	Copyright 2005-2021 Matthew Tylee Atkinson
 	Released under the GNU GPL v2 -- See ``COPYING'' for more information.
 
 	This file contains the common code across all stack stages.


### PR DESCRIPTION
* Implement an "About" box (this is shown on start-up until the game has been run at least once, and is accessible via the launcher's "Help" tab too).
* Include more documentation in the launcher's GUI (it's also still in the "docs" directory.
* Don't allow the launcher window to be resized.
* Cap the size of the HTMLPageDialogs (though they can be maximised/resized still).
* Update more "2020" to "2021" references.
* Rename the LDL tutorial file (the abbreviation should've been upper-case).