### PR TITLE
chore: Package bumps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,12 @@ pywin32==300; sys_platform=="win32"
 winshell==0.6; sys_platform=="win32"
 mistune==0.8.4
 mistune-contrib==0.1
-PyInstaller==4.1
+PyInstaller==4.2
 vgio==1.2.0
 
 argcomplete==1.12.2
 xmltodict==0.12.0
 patch_ng==1.17.4
 
-flake8==3.8.4
-md-toc==7.0.5
+flake8==3.9.0
+md-toc==7.1.0


### PR DESCRIPTION
After these bumps, pip says that the package idna is not the most up-to-date. Thanks to [pipdeptree](https://stackoverflow.com/questions/9232568/identifying-the-dependency-relationship-for-python-packages-installed-with-pip) it's required by md-toc. From checking idna's HISTORY file, it doesn't seem like any urgent action on that is needed.