### PR TITLE
fix: Start server and rcon in their own processes on Windows

### DIFF
--- a/audioquake/launcherlib/ui/tabs/play.py
+++ b/audioquake/launcherlib/ui/tabs/play.py
@@ -1,8 +1,5 @@
 """AudioQuake & LDL Launcher - Play tab"""
-try:
-	from subprocess import run, CalledProcessError, CREATE_NEW_CONSOLE
-except ImportError:
-	pass
+import os  # on Windows
 
 import wx
 import wx.html2
@@ -56,7 +53,9 @@ def start_server_windows(event):
 
 
 def run_win_console(prog):
-	run(prog, creationflags=CREATE_NEW_CONSOLE)
+	args = [str(x) for x in prog]
+	command = ' '.join(args)
+	os.system(f'start cmd /k {command}')
 
 
 #
@@ -128,7 +127,7 @@ class PlayTab(wx.Panel):
 				set_only=True),
 			"Remote console": doset(
 				mac=lambda evt: run_apple_script(dirs.gubbins / 'rcon'),
-				windows=lambda evt: run_win_console(dirs.gubbins / 'rcon.exe'),
+				windows=lambda evt: run_win_console([dirs.gubbins / 'rcon.exe']),
 				set_only=True)
 		}
 

--- a/audioquake/launcherlib/ui/tabs/play.py
+++ b/audioquake/launcherlib/ui/tabs/play.py
@@ -1,5 +1,12 @@
 """AudioQuake & LDL Launcher - Play tab"""
-import os  # on Windows
+from platform import system
+
+if system() == 'Darwin':
+	from subprocess import run, CalledProcessError
+elif system() == 'Windows':
+	import os
+else:
+	raise NotImplementedError
 
 import wx
 import wx.html2


### PR DESCRIPTION
This avoids the UI being locked up. Checked with NVDA.