### PR TITLE
fix: Remove some video modes

### DIFF
--- a/audioquake/launcherlib/config.py
+++ b/audioquake/launcherlib/config.py
@@ -11,8 +11,6 @@ INITIAL_CONFIG = {
 	'_validation': '',  # This will be set by code.
 	'first_game_run': 'yes',
 	'warning_acknowledged_flickering': 'no',
-	'warning_acknowledged_flickering_mode_test': 'no',
-	'fullscreen': 'no',
 	'resolution': ''    # The default will be inserted.
 }
 

--- a/audioquake/launcherlib/config.py
+++ b/audioquake/launcherlib/config.py
@@ -13,7 +13,7 @@ INITIAL_CONFIG = {
 	'warning_acknowledged_flickering': 'no',
 	'warning_acknowledged_flickering_mode_test': 'no',
 	'fullscreen': 'no',
-	'resolution': ''    # The platform default will be inserted.
+	'resolution': ''    # The default will be inserted.
 }
 
 _config_file_path = None

--- a/audioquake/launcherlib/game_controller/__init__.py
+++ b/audioquake/launcherlib/game_controller/__init__.py
@@ -1,7 +1,6 @@
 """AudioQuake & LDL Launcher - Game controller"""
 import enum
 
-import launcherlib.config as config
 from launcherlib import dirs
 from launcherlib.utils import have_registered_data, LaunchState
 from launcherlib.game_controller.engine_wrapper import EngineWrapper
@@ -37,12 +36,10 @@ class GameController():
 		if self._is_running():
 			return LaunchState.ALREADY_RUNNING
 
-		screen_mode = ('',) if config.fullscreen() else ('-window',)
-
 		x, y = resolution_from_config()
-		resolution = ('-width', str(x), '-height', str(y))
+		screen_mode = ('-window', '-width', str(x), '-height', str(y))
 
-		parameters = self.opts_default + options + screen_mode + resolution
+		parameters = self.opts_default + options + screen_mode
 
 		if game is RootGame.ANY:
 			if have_registered_data():
@@ -59,7 +56,6 @@ class GameController():
 		else:
 			raise TypeError(f'Invalid game name "{game}"')
 
-		print(parameters)
 		self._engine_wrapper = EngineWrapper(parameters, self._on_error)
 
 		if not self._engine_wrapper.engine_found():

--- a/audioquake/launcherlib/game_controller/__init__.py
+++ b/audioquake/launcherlib/game_controller/__init__.py
@@ -5,8 +5,7 @@ import launcherlib.config as config
 from launcherlib import dirs
 from launcherlib.utils import have_registered_data, LaunchState
 from launcherlib.game_controller.engine_wrapper import EngineWrapper
-from launcherlib.resolutions import resolution_size_from_config, \
-	DEFAULT_WIDTH, DEFAULT_HEIGHT
+from launcherlib.resolutions import resolution_from_config
 
 
 class RootGame(enum.Enum):
@@ -38,13 +37,10 @@ class GameController():
 		if self._is_running():
 			return LaunchState.ALREADY_RUNNING
 
-		screen_mode = ('-fullscreen',) if config.fullscreen() else ('-window',)
+		screen_mode = ('',) if config.fullscreen() else ('-window',)
 
-		xstr, ystr, _ = resolution_size_from_config()
-		if xstr == DEFAULT_WIDTH and ystr == DEFAULT_HEIGHT:
-			resolution = ()
-		else:
-			resolution = ('-width', xstr, '-height', ystr)
+		x, y = resolution_from_config()
+		resolution = ('-width', str(x), '-height', str(y))
 
 		parameters = self.opts_default + options + screen_mode + resolution
 
@@ -63,6 +59,7 @@ class GameController():
 		else:
 			raise TypeError(f'Invalid game name "{game}"')
 
+		print(parameters)
 		self._engine_wrapper = EngineWrapper(parameters, self._on_error)
 
 		if not self._engine_wrapper.engine_found():

--- a/audioquake/launcherlib/resolutions.py
+++ b/audioquake/launcherlib/resolutions.py
@@ -1,92 +1,17 @@
 """AudioQuake & LDL Launcher - Customise tab"""
 # FIXME: enforce min and max resolutions
-from buildlib import doset
 import launcherlib.config as config
 
-RESOLUTIONS = [
-	'640x400 (16:10)',  # Default on macOS
-	'640x480 (4:3)',    # Default on Windows
-	'800x600 (4:3)',
-	'1152x720 (16:10)',
-	'1280x720 (16:9)',
-	'1024x768 (4:3)']
-
-DEFAULT_RESOLUTION_INDEX = doset(mac=0, windows=1)
-
-RESOLUTIONS[DEFAULT_RESOLUTION_INDEX] += ' [default]'
+RESOLUTIONS = [(640, 480), (800, 600), (1024, 768)]
+DEFAULT_RESOLUTION_INDEX = 0
 
 
-def width_and_height(resolution_string):
-	"""Given a string, extract the width and height of the corresponding
-	resolution
-
-	Raises ValueError if the string doesn't describe a resolution"""
-	if ' ' in resolution_string:
-		dimensions = resolution_string.split(' ')[0]
-	else:
-		dimensions = resolution_string
-	xstr, ystr = dimensions.split('x')  # may raise ValueError
-	return xstr, ystr
-
-
-DEFAULT_WIDTH, DEFAULT_HEIGHT = \
-	width_and_height(RESOLUTIONS[DEFAULT_RESOLUTION_INDEX])
-
-
-def resolution_index_and_size(partial_resolution_string):
-	"""Given a resolution string, find the index of the matching preset
-	resolution, if it exists
-
-	Returns
-		(index,    x,    y)  if the string matches a preset resolution
-		(   -1,    x,    y)  if the string's resolution doesn't match a preset
-		(   -2, None, None)  if the string's resolution is invalid"""
+def resolution_from_config():
 	try:
-		given_xstr, given_ystr = width_and_height(partial_resolution_string)
-	except ValueError:
-		return -2, None, None
-
-	for index, resolution_string in enumerate(RESOLUTIONS):
-		res_xstr, res_ystr = width_and_height(resolution_string)
-		if given_xstr == res_xstr and given_ystr == res_ystr:
-			return index, given_xstr, given_ystr
-
-	return -1, given_xstr, given_ystr
-
-
-def resolution_details_from_config():
-	"""Gets and updates info about the resolution string stored in the
-	launcher's INI file.
-
-	If the resolution is valid syntactically, works out if it's one of the
-	preset ones and finds its index if so.
-
-	Also finds the x and y sizes of the resultion.
-
-	If the resolution in the INI file is not syntactically correct, replace it
-	with the default resolution string for the current platform, then return
-	the info on the default resolution.
-
-	Returns
-		index     - int/None depending on whether the current res is a preset
-		x         - width of current resolution
-		y         - height of current resolution
-		was_valid - Whether the INI file res was syntactically correct."""
-	index, x, y = resolution_index_and_size(config.resolution())
-	if index >= 0:
-		return index, x, y, True
-	elif index == -1:
-		return None, x, y, True
-	else:
-		config.resolution(RESOLUTIONS[DEFAULT_RESOLUTION_INDEX])
-		return DEFAULT_RESOLUTION_INDEX, DEFAULT_WIDTH, DEFAULT_HEIGHT, False
-
-
-def resolution_index_from_config():
-	index, _, _, was_valid = resolution_details_from_config()
-	return index, was_valid
-
-
-def resolution_size_from_config():
-	_, x, y, was_valid = resolution_details_from_config()
-	return x, y, was_valid
+		index = int(config.resolution())
+		x, y = RESOLUTIONS[index]
+		return x, y
+	except:  # noqa 722
+		x, y = RESOLUTIONS[DEFAULT_RESOLUTION_INDEX]
+		config.resolution(DEFAULT_RESOLUTION_INDEX)
+		return x, y

--- a/giants/zq-repo/zquake/source/vid_glsdl.c
+++ b/giants/zq-repo/zquake/source/vid_glsdl.c
@@ -299,6 +299,7 @@ static void uninstall_grabs(void)
 
 void HotKey_ToggleFullScreen(void)
 {
+#ifndef AGRIP
 	SDL_Surface *screen;
 
 	screen = SDL_GetVideoSurface();
@@ -310,6 +311,7 @@ void HotKey_ToggleFullScreen(void)
 		flags ^= SDL_FULLSCREEN;
 		screen = SDL_SetVideoMode(screen->w, screen->h, bpp, flags);
 	}
+#endif
 }
 
 void HotKey_ToggleGrab(void)
@@ -493,8 +495,10 @@ void VID_Init(unsigned char *palette)
 
 	vid.colormap = host_colormap;
 
+#ifndef AGRIP
 	if (!(COM_CheckParm("-window")) )
 		flags |= SDL_FULLSCREEN;
+#endif
 
 	if ((i = COM_CheckParm("-bpp")) != 0)
 		bpp = atoi(com_argv[i+1]);

--- a/giants/zq-repo/zquake/source/vid_wgl.c
+++ b/giants/zq-repo/zquake/source/vid_wgl.c
@@ -1611,8 +1611,10 @@ void	VID_Init (unsigned char *palette)
 
 	VID_InitFullDIB (global_hInstance);
 
+#ifndef AGRIP
 	if (COM_CheckParm("-window") || COM_CheckParm("-startwindowed"))
 	{
+#endif
 		hdc = GetDC (NULL);
 
 		if (GetDeviceCaps(hdc, RASTERCAPS) & RC_PALETTE)
@@ -1625,6 +1627,7 @@ void	VID_Init (unsigned char *palette)
 		windowed = true;
 
 		vid_default = MODE_WINDOWED;
+#ifndef AGRIP
 	}
 	else
 	{
@@ -1781,6 +1784,7 @@ void	VID_Init (unsigned char *palette)
 			}
 		}
 	}
+#endif
 
 	vid_initialized = true;
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pywin32==301; sys_platform=="win32"
 winshell==0.6; sys_platform=="win32"
 mistune==0.8.4
 mistune-contrib==0.1
-PyInstaller==4.3
+PyInstaller==4.2
 vgio==1.2.0
 python-dateutil==2.8.1
 


### PR DESCRIPTION
On the Mac, some non-4:3 modes were causing serious flickering (only on some
Macs). This is bad enough to pull fullscreen for now. Hasn't happened on
Windows that I can test, but pulling there too.